### PR TITLE
Working docker instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Build this module with `caddy` at Caddy's official [download](https://caddyserve
 CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake
 ```
 
-### Use Docker to build
+### Use Docker to build (or Podman)
 
 Dockerfile:
 
@@ -43,16 +43,18 @@ RUN apt-get update -y &&\
     wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz &&\
     tar -xvf go1.21.6.linux-amd64.tar.gz &&\
     rm -rf go1.21.6.linux-amd64.tar.gz &&\
-    mv go /usr/local &&\
-    export GOROOT=/usr/local/go &&\
-    export GOPATH=$HOME/go &&\
-    export PATH=$GOPATH/bin:$GOROOT/bin:$PATH &&\
-    go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-
+    mv go /usr/local
+ENV GOROOT=/usr/local/go
+ENV GOPATH=$HOME/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 RUN CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake
 
 # Use caddy binary located in: /root/caddy
 ```
+
+* `docker build -f Dockerfile -t caddy-snake`
+* `docker cp caddy-snake:/root/caddy ./caddy`
 
 ## Example Caddyfile
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-RUN CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake
+RUN CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake@main
 
 # Use caddy binary located in: /root/caddy
 ```


### PR DESCRIPTION
* `ENV` allows environment variables to persist.. currently they do not and the build is broken.
* Some simple instructions on how to copy the `caddy` binary out.
* Note that you can also use Podman.