### PR TITLE
Python3 compatibility with older versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-          cache-dependency-path: |
-            go.sum
+          cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install -yyqq software-properties-common
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
-          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc || true
+          sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
           python${{ matrix.python-version }} -m venv venv
           source venv/bin/activate
           pip install Flask

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install -yyqq software-properties-common
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
-          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc || true
           python${{ matrix.python-version }} -m venv venv
           source venv/bin/activate
           pip install Flask

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,51 @@
+---
+name: Tests
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    env:
+      GOEXPERIMENT: cgocheck2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache-dependency-path: |
+            go.sum
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Set up Python ${{ matrix.python-version }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update -yyqq
+          sudo apt-get install -yyqq software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
+          sudo cp /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+          python${{ matrix.python-version }} -m venv venv
+          source venv/bin/activate
+          pip install Flask
+      - name: Install global python dependencies
+        run: sudo pip install requests
+      - name: Run module tests
+        run: go test -race -v ./...
+      - name: Build the server
+        working-directory: examples/
+        run: CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake=..
+      - name: Run integration tests
+        working-directory: examples/
+        run: |
+          PYTHONPATH="../venv/lib/python${{ matrix.python-version }}/site-packages/" ./caddy run --config Caddyfile &
+          sleep 10
+          python ../examples_test.py

--- a/README.md
+++ b/README.md
@@ -6,25 +6,24 @@ It embeds the Python interpreter inside Caddy and serves requests directly witho
 
 ## Install
 
-Go 1.21 and Python 3.12 or later is required, with development files to embed the interpreter.
+Go 1.21 and Python 3.9 or later is required, with development files to embed the interpreter.
 
-To install Python3.12 in Ubuntu do:
+To install in Ubuntu do:
 
 ```bash
-apt-get install -y software-properties-common
-add-apt-repository ppa:deadsnakes/ppa
-apt-get install -y python3.12-dev
+sudo apt-get update
+sudo apt-get install -y python3-dev
 ```
 
 To install in MacOS do:
 
 ```bash
-brew install python@3.12
+brew install python@3
 ```
 
 ### Bundling with Caddy
 
-Build this module with `caddy` at Caddy's official [download](https://caddyserver.com/download) site. Or:
+Build this module using [xcaddy](https://github.com/caddyserver/xcaddy):
 
 ```bash
 CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake
@@ -43,12 +42,13 @@ RUN apt-get update -y &&\
     wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz &&\
     tar -xvf go1.21.6.linux-amd64.tar.gz &&\
     rm -rf go1.21.6.linux-amd64.tar.gz &&\
-    mv go /usr/local
+    mv go /usr/local &&\
+    cp /usr/lib/x86_64-linux-gnu/pkgconfig/python-3.12-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
 ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-RUN CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake@v0.0.2
+RUN CGO_ENABLED=1 xcaddy build --with github.com/mliezun/caddy-snake
 
 # Use caddy binary located in: /root/caddy
 ```

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -1,7 +1,7 @@
 // Caddy plugin that gives native support for Python WSGI apps.
 package caddysnake
 
-// #cgo pkg-config: python-3.12-embed
+// #cgo pkg-config: python3-embed
 // #include "caddysnake.h"
 import "C"
 import (

--- a/examples_test.py
+++ b/examples_test.py
@@ -1,0 +1,15 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+import requests
+
+def do_requests(app: str, n: int = 1_000):
+    for _ in range(n):
+        r = requests.get(f"http://localhost:9080/{app}")
+        r.raise_for_status()
+    return n
+
+with ThreadPoolExecutor(max_workers=8) as t:
+    start = time.time()
+    request_count = sum(t.map(do_requests, ["app1", "app2"]*4))
+    print(f"Done {request_count=}")
+    print(f"Elapsed: {time.time()-start}s")


### PR DESCRIPTION
- Use python c api functions that are compatible with multiple versions.
- Check that we're compiling agains an accepted version, otherwise it aborts compilation.
- Added tests to check it compiles and runs with all supported python versions.
- Updated Readme with instructions to build using *any* supported python version.