### PR TITLE
Support for venv in Caddyfile

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,8 +32,8 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
           sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
-          python${{ matrix.python-version }} -m venv venv
-          source venv/bin/activate
+          python${{ matrix.python-version }} -m venv examples/venv
+          source examples/venv/bin/activate
           pip install Flask fastapi a2wsgi
       - name: Install global python dependencies
         run: sudo pip install requests
@@ -45,6 +45,6 @@ jobs:
       - name: Run integration tests
         working-directory: examples/
         run: |
-          PYTHONPATH="../venv/lib/python${{ matrix.python-version }}/site-packages/" ./caddy run --config Caddyfile &
+          ./caddy run --config Caddyfile &
           sleep 10
           python ../examples_test.py

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:latest
+
+ARG GO_VERSION=1.22.1
+ARG PY_VERSION=3.12
+
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get update -yyqq &&\
+    apt-get install -yyqq wget tar software-properties-common gcc pkgconf &&\
+    add-apt-repository -y ppa:deadsnakes/ppa &&\
+    apt-get update -yyqq &&\
+    apt-get install -yyqq python${PY_VERSION}-dev &&\
+    mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${PY_VERSION}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go*.linux-amd64.tar.gz && \
+    rm go*.linux-amd64.tar.gz
+
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest &&\
+    cd /usr/local/bin &&\
+    CGO_ENABLED=1 /root/go/bin/xcaddy build --with github.com/mliezun/caddy-snake &&\
+    rm -rf /build
+
+CMD ["cp", "/root/caddy", "/output/caddy"]

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -22,4 +22,4 @@ RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest &&\
     CGO_ENABLED=1 /root/go/bin/xcaddy build --with github.com/mliezun/caddy-snake &&\
     rm -rf /build
 
-CMD ["cp", "/root/caddy", "/output/caddy"]
+CMD ["cp", "/usr/local/bin/caddy", "/output/caddy"]

--- a/caddysnake.c
+++ b/caddysnake.c
@@ -161,12 +161,19 @@ static PyTypeObject ResponseType = {
     .tp_methods = Response_methods,
 };
 
-WsgiApp *App_import(const char *module_name, const char *app_name) {
+WsgiApp *App_import(const char *module_name, const char *app_name,
+                    const char *venv_path) {
   WsgiApp *app = malloc(sizeof(WsgiApp));
   if (app == NULL) {
     return NULL;
   }
   PyGILState_STATE gstate = PyGILState_Ensure();
+
+  // Add venv_path into sys.path list
+  if (venv_path) {
+    PyObject *sysPath = PySys_GetObject("path");
+    PyList_Append(sysPath, PyUnicode_FromString(venv_path));
+  }
 
   PyObject *module = PyImport_ImportModule(module_name);
   if (module == NULL) {
@@ -379,7 +386,6 @@ void Py_init_and_release_gil() {
   if (PyStatus_Exception(status)) {
     goto exception;
   }
-  config.write_bytecode = 0;
   status = Py_InitializeFromConfig(&config);
   if (PyStatus_Exception(status)) {
     goto exception;

--- a/caddysnake.h
+++ b/caddysnake.h
@@ -16,7 +16,7 @@ typedef struct {
 } HTTPHeaders;
 HTTPHeaders *HTTPHeaders_new(size_t);
 
-WsgiApp *App_import(const char *, const char *);
+WsgiApp *App_import(const char *, const char *, const char *);
 void App_handle_request(WsgiApp *, int64_t, HTTPHeaders *, const char *);
 void App_cleanup(WsgiApp *);
 

--- a/examples/Caddyfile
+++ b/examples/Caddyfile
@@ -10,7 +10,10 @@ localhost:9080 {
 		python "simple_app:main"
 	}
 	route /app2 {
-		python "example_flask:app"
+		python {
+			module_wsgi "example_flask:app"
+			venv "./venv"
+		}
 	}
 	route /app3 {
 		python "simple_exception:main"


### PR DESCRIPTION
## Description

Now it's possible to provide a path to the desired `venv` for each python app.

Using the following syntax:

```Caddyfile
python {
  module_wsgi "simple_app:main"
  venv_path "./venv"
}
```

It looks for the `site-packages` folder inside venv and appends that to `sys.path`.

## Work done

- Parse new Caddyfile format for python apps, also support old format.
- Validate that `site-packages` folder is present inside the venv_path.
- Updated Readme with improved instructions in how to build with docker and how to use published images.
- Adapted examples and tests to the new syntax.
