### PR TITLE
Use lowercase headers in ASGI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,7 +74,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           build-args: PY_VERSION=${{ matrix.python-version }}
-          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-py${{ matrix.python-version }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-py${{ matrix.python-version }}"
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ endsWith(github.ref_name, '/merge') && 'dev' || github.ref_name }}-py${{ matrix.python-version }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-py${{ matrix.python-version }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -587,7 +587,7 @@ func (m *Asgi) HandleRequest(w http.ResponseWriter, r *http.Request) error {
 			joinStr = "; "
 		}
 
-		key_str := C.CString(k)
+		key_str := C.CString(strings.ToLower(k))
 		defer C.free(unsafe.Pointer(key_str))
 		value_str := C.CString(strings.Join(items, joinStr))
 		defer C.free(unsafe.Pointer(value_str))


### PR DESCRIPTION
According to the [spec](https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope) it is preferred but not required to use lowercase in header keys. From issue #17 it arises that FastAPI cannot detect headers correctly unless the keys are lowercase.