### PR TITLE
Implement feature and notify user

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -41,6 +41,10 @@
               sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
               if [ "${{ matrix.architecture }}" = "x86_64" ]; then
                 sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+              elif [ "${{ matrix.architecture }}" = "arm64" ]; then
+                if [ -f /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc ]; then
+                  sudo mv /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/aarch64-linux-gnu/pkgconfig/python3-embed.pc
+                fi
               fi
           - name: Install global python dependencies
             run: sudo pip install requests

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -42,6 +42,10 @@ jobs:
           sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
           if [ "${{ matrix.architecture }}" = "x86_64" ]; then
             sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+          elif [ "${{ matrix.architecture }}" = "arm64" ]; then
+            if [ -f /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc ]; then
+              sudo mv /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/aarch64-linux-gnu/pkgconfig/python3-embed.pc
+            fi
           fi
           rm -rf venv
           python${{ matrix.python-version }} -m venv venv
@@ -60,6 +64,10 @@ jobs:
           sudo apt-get install -yyqq python${{ matrix.python-version }} python3.13-dev
           if [ "${{ matrix.architecture }}" = "x86_64" ]; then
             sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+          elif [ "${{ matrix.architecture }}" = "arm64" ]; then
+            if [ -f /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc ]; then
+              sudo mv /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/aarch64-linux-gnu/pkgconfig/python3-embed.pc
+            fi
           fi
           python${{ matrix.python-version }} -m venv --without-pip venv
           source venv/bin/activate

--- a/.github/workflows/leak-tests-linux.yml
+++ b/.github/workflows/leak-tests-linux.yml
@@ -46,6 +46,10 @@
               sudo apt-get install -yyqq python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-venv
               if [ "${{ matrix.architecture }}" = "x86_64" ]; then
                 sudo mv /usr/lib/x86_64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/x86_64-linux-gnu/pkgconfig/python3-embed.pc
+              elif [ "${{ matrix.architecture }}" = "arm64" ]; then
+                if [ -f /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc ]; then
+                  sudo mv /usr/lib/aarch64-linux-gnu/pkgconfig/python-${{ matrix.python-version }}-embed.pc /usr/lib/aarch64-linux-gnu/pkgconfig/python3-embed.pc
+                fi
               fi
               rm -rf venv
               python${{ matrix.python-version }} -m venv venv


### PR DESCRIPTION
Add ARM64 pkg-config path handling to CI workflows to support ARM64 architecture and resolve test failures.

This change ensures that pkg-config files are correctly located for both x86_64 and ARM64 architectures, particularly when tests are executed within QEMU emulation environments, which should address existing CI failures related to ARM64 builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-89cc7eb8-0b25-44e3-92c0-dbae3edafd17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89cc7eb8-0b25-44e3-92c0-dbae3edafd17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ARM64-specific handling for Python pkg-config embed files across CI workflows to enable ARM64 test/build runs.
> 
> - **CI Workflows**:
>   - Update `go-tests.yml`, `integration-tests-linux.yml`, and `leak-tests-linux.yml` to handle ARM64:
>     - Add `elif arm64` branch during Python setup to move `aarch64-linux-gnu/pkgconfig/python-<ver>-embed.pc` to `python3-embed.pc` when present.
>     - Maintain existing behavior for `x86_64`; no other logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edb2fb926c74d7eb90ba4d58029fa815ac127bf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->