### PR TITLE
GitHub actions security

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,4 +1,5 @@
 name: Caddy Binary Linux
+
 on:
   pull_request:
     branches:
@@ -9,6 +10,9 @@ on:
   release:
     types:
       - published
+
+permissions: {}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,4 +1,3 @@
----
 name: Caddy Binary Linux
 on:
   pull_request:
@@ -21,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -42,7 +42,7 @@ jobs:
           fi
           echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
       - name: Rename binary
-        run: mv caddy caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
+        run: mv caddy caddy-linux-${{ steps.choose-arch.outputs.ARCH }} # zizmor: ignore[template-injection]
       - name: Upload caddy binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -50,11 +50,11 @@ jobs:
           path: caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
       - name: Package caddy binary
         if: github.event_name == 'release'
-        run: |
+        run: | # zizmor: ignore[template-injection]
           tar -czf caddy-linux-${{ steps.choose-arch.outputs.ARCH }}.tar.gz caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
       - name: Upload to release
         if: github.event_name == 'release'
-        run: |
+        run: | # zizmor: ignore[template-injection]
           gh release upload ${{ github.event.release.tag_name }} caddy-linux-${{ steps.choose-arch.outputs.ARCH }}.tar.gz --repo ${{ github.repository }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -11,7 +11,8 @@ on:
     types:
       - published
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -21,10 +21,10 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
@@ -44,7 +44,7 @@ jobs:
       - name: Rename binary
         run: mv caddy caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
       - name: Upload caddy binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
           path: caddy-linux-${{ steps.choose-arch.outputs.ARCH }}

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -1,4 +1,5 @@
 name: Caddy Standalone Linux
+
 on:
   pull_request:
     branches:
@@ -9,6 +10,9 @@ on:
   release:
     types:
       - published
+
+permissions: {}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Retrieve python build standalone
         if: matrix.python-version != '3.13-nogil'
         working-directory: cmd/embed
-        run: |
+        run: | # zizmor: ignore[template-injection]
           python3 pybs.py latest --python-version ${{ matrix.python-version }} --architecture ${{ steps.choose-arch.outputs.PYBS_ARCH }} --build-config pgo+lto --content-type install_only_stripped
           mv cpython-*.tar.gz python-standalone.tar.gz
           go build main.go
@@ -57,7 +57,7 @@ jobs:
       - name: Retrieve python build standalone (nogil)
         if: matrix.python-version == '3.13-nogil'
         working-directory: cmd/embed
-        run: |
+        run: | # zizmor: ignore[template-injection]
           python3 pybs.py latest --python-version 3.13 --architecture ${{ steps.choose-arch.outputs.PYBS_ARCH }} --build-config freethreaded+pgo+lto --content-type full
           tar -xf cpython-*.tar.zst
           mv python/install .
@@ -74,11 +74,11 @@ jobs:
             cmd/embed/caddy
       - name: Package caddy standalone
         if: github.event_name == 'release'
-        run: |
+        run: | # zizmor: ignore[template-injection]
           tar -czf caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}.tar.gz cmd/embed/caddy
       - name: Upload to release
         if: github.event_name == 'release'
-        run: |
+        run: | # zizmor: ignore[template-injection]
           gh release upload ${{ github.event.release.tag_name }} caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}.tar.gz --repo ${{ github.repository }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -11,7 +11,8 @@ on:
     types:
       - published
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -1,4 +1,3 @@
----
 name: Caddy Standalone Linux
 on:
   pull_request:
@@ -15,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13', '3.13-nogil', '3.14']
+        python-version: ["3.12", "3.13", "3.13-nogil", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
@@ -40,7 +39,7 @@ jobs:
           echo "PYBS_ARCH=${PYBS_ARCH}" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - name: Retrieve python build standalone
         if: matrix.python-version != '3.13-nogil'
         working-directory: cmd/embed

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -22,10 +22,10 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
@@ -43,7 +43,7 @@ jobs:
             PYBS_ARCH=x86_64_v2-unknown-linux-gnu
           fi
           echo "PYBS_ARCH=${PYBS_ARCH}" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - name: Retrieve python build standalone
@@ -67,7 +67,7 @@ jobs:
           go build main.go
           mv main caddy
       - name: Upload caddy standalone
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}
           path: |

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -29,9 +29,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
+        run: rustup toolchain install stable
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: Build the CLI binary

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -1,4 +1,5 @@
 name: CLI Tests
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -1,4 +1,3 @@
----
 name: CLI Tests
 on:
   pull_request:
@@ -18,11 +17,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install Xcaddy

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -18,18 +18,20 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: Build the CLI binary

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -24,6 +24,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    environment: docker-publish
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -2,7 +2,7 @@ name: Docker Latest
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.14']
+        python-version: ["3.14"]
         os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -31,7 +31,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: "v2.1.1"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ["main"]
 
+permissions: {}
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY_GHCR: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    environment: docker-publish
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions: {}
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY_GHCR: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,9 @@ name: Docker
 
 on:
   push:
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ["3.12", "3.13", "3.14"]
         os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -33,7 +33,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: "v2.1.1"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -1,4 +1,5 @@
 name: Embed App Tests
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   embed-app:
     strategy:

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -19,16 +19,16 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
       - name: Install xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - name: Choose architecture

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Build embed-app binary
         working-directory: cmd/embed-app
-        run: |
+        run: | # zizmor: ignore[template-injection]
           ./build.sh app.zip ${{ matrix.python-version }} --output embed-test --arch ${{ steps.arch.outputs.arch }}
       - name: Run embed-app and verify
         working-directory: cmd/embed-app

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -1,4 +1,3 @@
----
 name: Embed App Tests
 on:
   pull_request:
@@ -12,20 +11,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ["3.12", "3.13"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - name: Install xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - name: Choose architecture
         id: arch
         run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,4 +1,5 @@
 name: Go Tests
+
 on:
   pull_request:
     branches:
@@ -6,8 +7,9 @@ on:
   push:
     branches:
       - main
-permissions:
-  contents: write
+
+permissions: {}
+
 jobs:
   tests:
     strategy:
@@ -15,6 +17,8 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -20,10 +20,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
@@ -36,7 +36,7 @@ jobs:
           go test -race -coverprofile=coverage.out -tags=caddytest -timeout 90s . || \
           go test -race -coverprofile=coverage.out .
       - name: Update coverage report
-        uses: ncruces/go-coverage-report@v0
+        uses: ncruces/go-coverage-report@dfc237255099f2d25066babde51253992175e365 # v0.3.2
         with:
           coverage-file: coverage.out
         continue-on-error: true

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,39 +1,38 @@
----
-    name: Go Tests
-    on:
-      pull_request:
-        branches:
-          - main
-      push:
-        branches:
-          - main
-    permissions:
-      contents: write
-    jobs:
-      tests:
-        strategy:
-          fail-fast: false
-          matrix:
-            os: [ubuntu-24.04, ubuntu-24.04-arm]
-        runs-on: ${{ matrix.os }}
-        steps:
-          - uses: actions/checkout@v4
-          - uses: actions/setup-go@v5
-            with:
-              go-version: '1.26'
-              cache: false
-          - name: Install Xcaddy
-            run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-          - name: Run module tests
-            run: go test -race -v .
-          - name: Run tests with coverage (including caddytest when available)
-            run: |
-              go test -race -coverprofile=coverage.out -tags=caddytest -timeout 90s . || \
-              go test -race -coverprofile=coverage.out .
-          - name: Update coverage report
-            uses: ncruces/go-coverage-report@v0
-            with:
-              coverage-file: coverage.out
-            continue-on-error: true
-          - name: Build the server
-            run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
+name: Go Tests
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Run module tests
+        run: go test -race -v .
+      - name: Run tests with coverage (including caddytest when available)
+        run: |
+          go test -race -coverprofile=coverage.out -tags=caddytest -timeout 90s . || \
+          go test -race -coverprofile=coverage.out .
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0
+        with:
+          coverage-file: coverage.out
+        continue-on-error: true
+      - name: Build the server
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -1,4 +1,3 @@
----
 name: Integration Tests Linux
 on:
   pull_request:
@@ -12,15 +11,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool-name: ['django', 'django_channels', 'flask', 'fastapi', 'simple_autoreload', 'simple_async', 'socketio', 'dynamic']
-        python-version: ['3.12', '3.13', '3.13t', '3.14']
+        tool-name:
+          - "django"
+          - "django_channels"
+          - "flask"
+          - "fastapi"
+          - "simple_autoreload"
+          - "simple_async"
+          - "socketio"
+          - "dynamic"
+        python-version: ["3.12", "3.13", "3.13t", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -28,16 +28,16 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up venv and install dependencies
@@ -68,7 +68,7 @@ jobs:
           python main_test.py || true
       - name: Upload logs and report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddy-integration-tests-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}-${{ matrix.os }}
           path: |

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -1,4 +1,5 @@
 name: Integration Tests Linux
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -11,7 +11,32 @@ on:
 permissions: {}
 
 jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Build the server
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
+      - name: Upload caddy binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: caddy-linux-${{ matrix.os }}
+          path: caddy
+
   tests:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -31,12 +56,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.26"
-          cache: false
-      - name: Install Xcaddy
-        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -47,13 +66,16 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt
-      - name: Build the server
-        working-directory: tests/${{ matrix.tool-name }}/
-        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
+      - name: Download caddy binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: caddy-linux-${{ matrix.os }}
+          path: tests/${{ matrix.tool-name }}/
       - name: Run integration tests
         working-directory: tests/${{ matrix.tool-name }}/
         if: matrix.python-version != '3.13-nogil'
         run: |
+          chmod +x caddy
           ./caddy run --config Caddyfile > caddy.log 2>&1 &
           timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" caddy.log; do sleep 1; done'
           source venv/bin/activate

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -19,17 +19,17 @@ jobs:
         tool-name: ["simple_async"]
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
@@ -61,7 +61,7 @@ jobs:
         shell: pwsh
       - name: Upload logs and report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddy-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -16,6 +16,8 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -1,4 +1,5 @@
 name: Integration Tests Windows
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   tests:
     runs-on: windows-latest

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -1,63 +1,62 @@
----
-    name: Integration Tests Windows
-    on:
-      pull_request:
-        branches:
-          - main
-      push:
-        branches:
-          - main
-    jobs:
-      tests:
-        runs-on: windows-latest
-        strategy:
-          fail-fast: false
-          matrix:
-            tool-name: ['simple_async']
-            python-version: ['3.14']
-        steps:
-          - uses: actions/checkout@v4
-          - uses: actions/setup-go@v5
-            with:
-              go-version: '1.26'
-              cache: false
-          - name: Install Xcaddy
-            run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-          - name: Set up Python
-            uses: actions/setup-python@v5
-            with:
-              python-version: ${{ matrix.python-version }}
-          - name: Install Python dependencies
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: |
-              python -m venv venv
-              .\venv\Scripts\activate
-              python -m pip install --upgrade pip
-              pip install -r requirements.txt
-            shell: pwsh
-          - name: Build caddy
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: |
-              $env:CGO_ENABLED = "0"
-              xcaddy build --with github.com/mliezun/caddy-snake=../..
-            shell: pwsh
-          - name: Run integration tests
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: |
-              touch caddy.log
-              Start-Process -FilePath "cmd.exe" -ArgumentList "/c", ".\caddy.exe run --config Caddyfile > caddy.log 2>&1"
-              $timeout = 60
-              while ($timeout -gt 0 -and -not (Select-String "finished cleaning storage units" -Path "caddy.log")) {
-                Start-Sleep -Seconds 1
-                $timeout -= 1
-              }
-              .\venv\Scripts\activate
-              python main_test.py
-            shell: pwsh
-          - name: Upload logs and report
-            if: always()
-            uses: actions/upload-artifact@v4
-            with:
-              name: caddy-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
-              path: |
-                tests/${{ matrix.tool-name }}/caddy.log
+name: Integration Tests Windows
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  tests:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool-name: ["simple_async"]
+        python-version: ["3.14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          python -m venv venv
+          .\venv\Scripts\activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+        shell: pwsh
+      - name: Build caddy
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          $env:CGO_ENABLED = "0"
+          xcaddy build --with github.com/mliezun/caddy-snake=../..
+        shell: pwsh
+      - name: Run integration tests
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          touch caddy.log
+          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", ".\caddy.exe run --config Caddyfile > caddy.log 2>&1"
+          $timeout = 60
+          while ($timeout -gt 0 -and -not (Select-String "finished cleaning storage units" -Path "caddy.log")) {
+            Start-Sleep -Seconds 1
+            $timeout -= 1
+          }
+          .\venv\Scripts\activate
+          python main_test.py
+        shell: pwsh
+      - name: Upload logs and report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: caddy-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
+          path: |
+            tests/${{ matrix.tool-name }}/caddy.log

--- a/.github/workflows/leak-tests-linux.yml
+++ b/.github/workflows/leak-tests-linux.yml
@@ -1,52 +1,51 @@
----
-    name: Leak Tests Linux
-    on:
-      pull_request:
-        branches:
-          - main
-      push:
-        branches:
-          - main
-    jobs:
-      tests:
-        runs-on: ubuntu-24.04
-        strategy:
-          fail-fast: false
-          matrix:
-            tool-name: ['django', 'socketio']
-            python-version: ['3.13']
-        steps:
-          - uses: actions/checkout@v4
-          - uses: actions/setup-go@v5
-            with:
-              go-version: '1.26'
-              cache: false
-          - name: Install Xcaddy
-            run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-          - uses: actions/setup-python@v5
-            with:
-              python-version: ${{ matrix.python-version }}
-          - name: Set up venv and install dependencies
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: |
-              rm -rf venv
-              python -m venv venv
-              source venv/bin/activate
-              pip install -r requirements.txt
-          - name: Build the server
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
-          - name: Run integration tests
-            working-directory: tests/${{ matrix.tool-name }}/
-            run: |
-              ./caddy run --config Caddyfile > caddy.log 2>&1 &
-              timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" caddy.log; do sleep 1; done'
-              source venv/bin/activate
-              python main_test.py
-          - name: Upload logs and report
-            if: always()
-            uses: actions/upload-artifact@v4
-            with:
-              name: caddy-leak-tests-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
-              path: |
-                tests/${{ matrix.tool-name }}/caddy.log
+name: Leak Tests Linux
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        tool-name: ["django", "socketio"]
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up venv and install dependencies
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          rm -rf venv
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+      - name: Build the server
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
+      - name: Run integration tests
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          ./caddy run --config Caddyfile > caddy.log 2>&1 &
+          timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" caddy.log; do sleep 1; done'
+          source venv/bin/activate
+          python main_test.py
+      - name: Upload logs and report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: caddy-leak-tests-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
+          path: |
+            tests/${{ matrix.tool-name }}/caddy.log

--- a/.github/workflows/leak-tests-linux.yml
+++ b/.github/workflows/leak-tests-linux.yml
@@ -1,4 +1,5 @@
 name: Leak Tests Linux
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/leak-tests-linux.yml
+++ b/.github/workflows/leak-tests-linux.yml
@@ -19,16 +19,16 @@ jobs:
         tool-name: ["django", "socketio"]
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
       - name: Install Xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up venv and install dependencies
@@ -50,7 +50,7 @@ jobs:
           python main_test.py
       - name: Upload logs and report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddy-leak-tests-logs-${{ matrix.tool-name }}-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/leak-tests-linux.yml
+++ b/.github/workflows/leak-tests-linux.yml
@@ -16,6 +16,8 @@ jobs:
         python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
 name: Lint
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   build:
     name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: false
       - name: Check pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
       - name: Go vet
         run: |
           go vet .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,3 @@
----
 name: Lint
 on:
   pull_request:
@@ -16,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache: false
       - name: Check pre-commit
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,7 +15,11 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
-    environment: pypi-publish
+    environment:
+      name: pypi-publish
+      url: https://pypi.org/p/caddysnake
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -51,12 +55,9 @@ jobs:
         with:
           name: caddysnake-cli-${{ matrix.python-version }}-${{ matrix.os }}
           path: cmd/cli/target/wheels/*.whl
-      - name: Publish package
-        run: |
-          cd cmd/cli/target/wheels
-          python${{ matrix.python-version }} -m pip install twine
-          python${{ matrix.python-version }} -m twine upload \
-            --skip-existing \
-            --username __token__ \
-            --password ${{ secrets.PYPI_API_TOKEN }} \
-            *.whl
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+          packages_dir: cmd/cli/target/wheels

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Choose architecture
@@ -35,7 +35,7 @@ jobs:
           docker build -f builder.Dockerfile --platform ${{ steps.choose-arch.outputs.DOCKER_PLATFORM }} --build-arg PY_VERSION=${{ matrix.python-version }} -t caddy-snake-builder .
           docker run --rm -v $(pwd):/output caddy-snake-builder
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build the CLI
@@ -45,7 +45,7 @@ jobs:
           python${{ matrix.python-version }} -m pip install maturin
           python${{ matrix.python-version }} -m maturin build --release
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: caddysnake-cli-${{ matrix.python-version }}-${{ matrix.os }}
           path: cmd/cli/target/wheels/*.whl

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Choose architecture
         id: choose-arch
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,6 +15,8 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
+    environment: pypi-publish
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,8 +1,11 @@
 name: Python Build Package - Linux
+
 on:
   push:
     tags: ["v*.*.*"]
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
       - name: Build Caddy with caddy-snake module
-        run: |
+        run: | # zizmor: ignore[template-injection]
           docker build -f builder.Dockerfile --platform ${{ steps.choose-arch.outputs.DOCKER_PLATFORM }} --build-arg PY_VERSION=${{ matrix.python-version }} -t caddy-snake-builder .
           docker run --rm -v $(pwd):/output caddy-snake-builder
       - name: Setup Python

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,7 +1,7 @@
 name: Python Build Package - Linux
 on:
   push:
-    tags: [ 'v*.*.*' ]
+    tags: ["v*.*.*"]
   workflow_dispatch:
 
 jobs:
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ["3.12", "3.13", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,5 @@
 name: Python Tests
+
 on:
   pull_request:
     branches:
@@ -6,6 +7,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   python-tests:
     strategy:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ["3.12", "3.13"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Run tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,10 +18,10 @@ jobs:
         python-version: ["3.12", "3.13"]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
This PR updates GitHub Actions workflow files to make the CI/CD pipeline more secure, predictable, and easier to maintain. This is primarily using [zizmor](https://docs.zizmor.sh/) to look for security improvements (`uv tool install zizmor && zizmor .`).

Taking inspiration from https://astral.sh/blog/open-source-security-at-astral

Changes in these commits:
- Reformat for consistency
- Turn off `persist-credentials` for `actions/checkout`
- Specify empty permissions at the workflow level and use job-scoped overrides
- Pin all actions to a specific commit SHA using [pinact](https://github.com/suzuki-shunsuke/pinact) (`go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@latest && pinact run`)
- Ignore irrelevant zizmor template injection warnings
- Use already-present `rustup install` instead of external action
- Add a workflow to automatically run zizmor to check for insecure actions
- Limit publishing secrets to specific environments
- Use PyPI Trusted Publishing instead of long-lived PyPI API token
- Build once per architecture for Linux integration tests, saving about 4 minutes of CI time

# Repository setting changes required

- Move the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets to a new `docker-publish` environment.
- Remove the `PYPI_API_TOKEN` secret.
- Add a new `pypi-publish` environment.
- Add a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) for the `caddysnake` project on PyPI.
  - Owner: `mliezun`
  - Repository name: `caddy-snake`
  - Workflow name: `python-build.yml`
  - Environment name: `pypi-publish`
- Recommended: require actions to be pinned to a full-length SHA:
  <img width="787" height="112" alt="image" src="https://github.com/user-attachments/assets/4629157a-fdac-41a4-b7ca-994d6aa20c4a" />
