### PR TITLE
ci: fix arm64 PyPI publish failure (`exec format error`) by splitting build/publish

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,12 +15,6 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
-    environment:
-      name: pypi-publish
-      url: https://pypi.org/p/caddysnake
-    permissions:
-      id-token: write
-
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -55,9 +49,28 @@ jobs:
         with:
           name: caddysnake-cli-${{ matrix.python-version }}-${{ matrix.os }}
           path: cmd/cli/target/wheels/*.whl
+
+  publish:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # The pypa/gh-action-pypi-publish action ships only a linux/amd64 image,
+    # so the publish job must run on an amd64 runner regardless of where the
+    # wheels were built.
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi-publish
+      url: https://pypi.org/p/caddysnake
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          pattern: caddysnake-cli-*
+          merge-multiple: true
       - name: Publish package to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
-          packages_dir: cmd/cli/target/wheels
+          packages-dir: dist


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After `v0.4.2`, all three `ubuntu-22.04-arm` jobs in `Python Build Package - Linux` failed at the `Publish package to PyPI` step:

```
Status: Downloaded newer image for ghcr.io/pypa/gh-action-pypi-publish:cef221092ed1bacb1cc03d23a2d87d1d172e277b
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
exec /app/twine-upload.sh: exec format error
```

`pypa/gh-action-pypi-publish` is a Docker container action whose image is published only for `linux/amd64`, so it cannot run on `ubuntu-22.04-arm` runners. As a result, the `0.4.2` release shipped only x86_64 wheels to PyPI; the aarch64 wheels were built but never uploaded.

This is also a noted limitation of the action — see [pypa/gh-action-pypi-publish discussion #353](https://github.com/pypa/gh-action-pypi-publish/discussions/353) and PyPA's recommended pattern in the [Trusted Publisher guide](https://docs.pypi.org/trusted-publishers/using-a-publisher/).

## Fix

Split `python-build.yml` into two jobs:

- **`build`** — keeps the existing `python-version × os` matrix (`ubuntu-22.04`, `ubuntu-22.04-arm`), builds wheels on each runner using `maturin`, and uploads them with `actions/upload-artifact`. No PyPI/OIDC permissions on this job.
- **`publish`** — runs once on `ubuntu-22.04` (amd64), downloads every wheel produced by the matrix, and publishes them via Trusted Publishing in a single OIDC exchange.

Additional cleanups:

- `pypi-publish` environment binding stays on the `publish` job, so the registered PyPI Trusted Publisher claims (owner / repo / workflow filename / environment) still match.
- The tag-only guard is moved to the job level so `workflow_dispatch` runs the build matrix without publishing.
- The deprecated input `packages_dir` is renamed to `packages-dir`, silencing the deprecation warning emitted by the action.
- `merge-multiple: true` on `actions/download-artifact` is safe here because every wheel filename is unique across the matrix (`caddysnake-<ver>-cp3xx-cp3xx-manylinux_2_xx_{x86_64,aarch64}.whl`).

## Result

After this change, the next tagged release will publish wheels for **both** architectures across Python 3.12 / 3.13 / 3.14 (six wheels total), each from a single OIDC token.

## Notes for the next release

To recover the missing `0.4.2` aarch64 wheels you have two options:

1. **Cut a new patch release** (e.g. `v0.4.3`) — both architectures will be uploaded by this workflow.
2. **Re-run only the publish step** — set `skip-existing: true` is already on, so re-running won't conflict with the existing amd64 wheels. You can either tag a no-op commit as `v0.4.2-rebuild` (PyPI won't accept duplicate version), or accept the missing arm64 wheels and ship them in `v0.4.3`.

Option 1 is cleanest.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-686797b3-6a72-4655-8d9c-dece37c93e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-686797b3-6a72-4655-8d9c-dece37c93e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

