### PR TITLE
Forward real client IP to Python worker (fixes #168)

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -7,16 +7,19 @@ inputs:
   push-image:
     description: If true, install cosign, log in, and push images
     required: true
-secrets:
-  GITHUB_TOKEN:
-    description: For GHCR login when push-image is true
+  # Registry credentials must be inputs (not secrets.* in composite steps — secrets context is invalid there).
+  ghcr_token:
+    description: secrets.GITHUB_TOKEN for GHCR when push-image is true
     required: false
-  DOCKER_USERNAME:
+    default: ""
+  docker_username:
     description: Docker Hub user when push-image is true
     required: false
-  DOCKER_PASSWORD:
+    default: ""
+  docker_password:
     description: Docker Hub token when push-image is true
     required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -35,15 +38,15 @@ runs:
       with:
         registry: ${{ env.REGISTRY_GHCR }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ inputs.ghcr_token }}
 
     - name: Log into Docker Hub
       if: inputs.push-image == 'true'
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
         registry: ${{ env.REGISTRY_DOCKER_HUB }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
 
     - name: Extract Docker metadata
       id: meta

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,0 +1,66 @@
+name: Docker build and push
+description: Build multi-arch caddy-snake image; optionally push to registries
+inputs:
+  python-version:
+    description: Python version for PY_VERSION build-arg
+    required: true
+  push-image:
+    description: If true, install cosign, log in, and push images
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
+
+    - name: Install cosign
+      if: inputs.push-image == 'true'
+      uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06
+      with:
+        cosign-release: "v2.1.1"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+    - name: Log into GitHub Container Registry
+      if: inputs.push-image == 'true'
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ env.REGISTRY_GHCR }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log into Docker Hub
+      if: inputs.push-image == 'true'
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ env.REGISTRY_DOCKER_HUB }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
+      with:
+        images: |
+          ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
+          ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      id: build-and-push
+      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+      with:
+        context: .
+        push: ${{ inputs.push-image == 'true' }}
+        build-args: PY_VERSION=${{ inputs.python-version }}
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:${{ endsWith(github.ref_name, '/merge') && 'dev' || github.ref_name }}-py${{ inputs.python-version }}
+          ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:latest-py${{ inputs.python-version }}
+          ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}:${{ endsWith(github.ref_name, '/merge') && 'dev' || github.ref_name }}-py${{ inputs.python-version }}
+          ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}:latest-py${{ inputs.python-version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -7,6 +7,16 @@ inputs:
   push-image:
     description: If true, install cosign, log in, and push images
     required: true
+secrets:
+  GITHUB_TOKEN:
+    description: For GHCR login when push-image is true
+    required: false
+  DOCKER_USERNAME:
+    description: Docker Hub user when push-image is true
+    required: false
+  DOCKER_PASSWORD:
+    description: Docker Hub token when push-image is true
+    required: false
 runs:
   using: composite
   steps:

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,5 +1,5 @@
 name: Docker build and push
-description: Build multi-arch caddy-snake image; optionally push to registries
+description: "Build multi-arch image; push optional. Caller must run actions/checkout before this local composite."
 inputs:
   python-version:
     description: Python version for PY_VERSION build-arg
@@ -20,11 +20,6 @@ secrets:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      with:
-        persist-credentials: false
-
     - name: Install cosign
       if: inputs.push-image == 'true'
       uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,10 @@ jobs:
       id-token: write
     environment: docker-publish
     steps:
+      # Required before uses: ./.github/actions/... — the runner must have the repo (and action.yml) on disk.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/docker-build-push
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           push-image: "true"
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,24 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-verify:
+    if: github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+        os: [ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: ./.github/actions/docker-build-push
+        with:
+          python-version: ${{ matrix.python-version }}
+          push-image: "false"
+        secrets: inherit
+
+  build-push:
+    if: github.event_name == 'push'
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
@@ -27,61 +44,9 @@ jobs:
       packages: write
       id-token: write
     environment: docker-publish
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/docker-build-push
         with:
-          persist-credentials: false
-
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06
-        with:
-          cosign-release: "v2.1.1"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
-
-      # Log into GitHub Container Registry
-      - name: Log into GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        with:
-          registry: ${{ env.REGISTRY_GHCR }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Log into Docker Hub
-      - name: Log into Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        with:
-          registry: ${{ env.REGISTRY_DOCKER_HUB }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
-        with:
-          images: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          build-args: PY_VERSION=${{ matrix.python-version }}
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:${{ endsWith(github.ref_name, '/merge') && 'dev' || github.ref_name }}-py${{ matrix.python-version }}
-            ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:latest-py${{ matrix.python-version }}
-            ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}:${{ endsWith(github.ref_name, '/merge') && 'dev' || github.ref_name }}-py${{ matrix.python-version }}
-            ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME }}:latest-py${{ matrix.python-version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          python-version: ${{ matrix.python-version }}
+          push-image: "true"
+        secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,11 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
+# Two jobs instead of one so pull requests do not attach jobs.environment: GitHub treats
+# that as a deployment (noisy PR UI, one row per matrix cell). Tag releases still use
+# the docker-publish environment for secrets and optional protection rules.
 jobs:
+  # PRs: build-only (push-image false). No environment, no registry secrets, least privilege.
   build-verify:
     if: github.event_name == 'pull_request'
     strategy:
@@ -30,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           push-image: "false"
-        secrets: inherit
 
+  # Release tags: push images, cosign, GHCR/Docker Hub — needs docker-publish env + secrets.
   build-push:
     if: github.event_name == 'push'
     strategy:
@@ -49,4 +53,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           push-image: "true"
-        secrets: inherit
+        secrets:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,43 +1,19 @@
-name: Docker
+# Tag releases only. Uses docker-publish environment for registry secrets / protection rules.
+name: Docker publish
 
 on:
   push:
     tags: ["v*.*.*"]
-  pull_request:
-    branches: ["main"]
 
 permissions: {}
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY_GHCR: ghcr.io
   REGISTRY_DOCKER_HUB: docker.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-# Two jobs instead of one so pull requests do not attach jobs.environment: GitHub treats
-# that as a deployment (noisy PR UI, one row per matrix cell). Tag releases still use
-# the docker-publish environment for secrets and optional protection rules.
 jobs:
-  # PRs: build-only (push-image false). No environment, no registry secrets, least privilege.
-  build-verify:
-    if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-        os: [ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    steps:
-      - uses: ./.github/actions/docker-build-push
-        with:
-          python-version: ${{ matrix.python-version }}
-          push-image: "false"
-
-  # Release tags: push images, cosign, GHCR/Docker Hub — needs docker-publish env + secrets.
   build-push:
-    if: github.event_name == 'push'
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]

--- a/.github/workflows/docker-verify.yml
+++ b/.github/workflows/docker-verify.yml
@@ -24,6 +24,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Required before uses: ./.github/actions/... — the runner must have the repo (and action.yml) on disk.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/docker-build-push
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docker-verify.yml
+++ b/.github/workflows/docker-verify.yml
@@ -1,0 +1,30 @@
+# PR Docker image build only (no push). Kept separate from docker-publish.yml so we never
+# use jobs.environment here — GitHub treats environment as a deployment (noisy PR UI, one
+# row per matrix cell when combined with publish jobs on the same workflow file).
+name: Docker
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+env:
+  REGISTRY_GHCR: ghcr.io
+  REGISTRY_DOCKER_HUB: docker.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+        os: [ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: ./.github/actions/docker-build-push
+        with:
+          python-version: ${{ matrix.python-version }}
+          push-image: "false"

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -42,6 +42,33 @@ import (
 //go:embed caddysnake.py
 var caddysnake_py string
 
+// Hop-internal headers: set only by the Go module after stripping client-supplied
+// values. The Python worker uses these for REMOTE_ADDR / ASGI client.
+const (
+	caddySnakeRemoteAddrHeader = "Caddy-Snake-Remote-Addr"
+	caddySnakeRemotePortHeader = "Caddy-Snake-Remote-Port"
+)
+
+// setPythonWorkerOutboundHeaders configures the outbound request to the Python
+// worker: target URL, standard X-Forwarded-* (preserve inbound X-Forwarded-For
+// chain, then append this hop per [httputil.ProxyRequest.SetXForwarded]), and
+// trusted Caddy-Snake-Remote-* from the inbound RemoteAddr.
+func setPythonWorkerOutboundHeaders(pr *httputil.ProxyRequest, dialAddr string) {
+	pr.Out.URL.Scheme = "http"
+	pr.Out.URL.Host = dialAddr
+	pr.Out.Header["X-Forwarded-For"] = pr.In.Header["X-Forwarded-For"]
+	pr.SetXForwarded()
+	pr.Out.Header.Del(caddySnakeRemoteAddrHeader)
+	pr.Out.Header.Del(caddySnakeRemotePortHeader)
+	host, port, err := net.SplitHostPort(pr.In.RemoteAddr)
+	if err != nil {
+		host = pr.In.RemoteAddr
+		port = "0"
+	}
+	pr.Out.Header.Set(caddySnakeRemoteAddrHeader, host)
+	pr.Out.Header.Set(caddySnakeRemotePortHeader, port)
+}
+
 // AppServer defines the interface to interacting with a WSGI or ASGI server
 type AppServer interface {
 	Cleanup() error
@@ -433,8 +460,7 @@ func (w *PythonWorker) Start() error {
 	}
 	w.Proxy = &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
-			req.Out.URL.Scheme = "http"
-			req.Out.URL.Host = w.DialAddr
+			setPythonWorkerOutboundHeaders(req, w.DialAddr)
 		},
 		Transport:  w.Transport,
 		BufferPool: sharedProxyBufferPool,

--- a/caddysnake.py
+++ b/caddysnake.py
@@ -16,6 +16,7 @@ import base64
 import concurrent.futures
 import hashlib
 import importlib
+import ipaddress
 import os
 import signal
 import struct
@@ -357,11 +358,38 @@ def _call_wsgi_app(app, environ):
             result.close()
 
 
+def _client_from_caddy_snake_headers(raw_headers):
+    """Parse trusted Caddy-Snake-Remote-* set by the Go worker. Returns (ip_str, port) or None."""
+    addr = raw_headers.get("caddy-snake-remote-addr")
+    if not addr:
+        return None
+    port_s = raw_headers.get("caddy-snake-remote-port", "0")
+    try:
+        port = int(port_s)
+        if port < 0 or port > 65535:
+            return None
+    except ValueError:
+        return None
+    host = addr.strip()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return None
+    return (str(ip), port)
+
+
 def _build_wsgi_environ(method, path, version, headers_list, raw_headers, wsgi_input):
     """Build a WSGI environ dict from parsed HTTP request components."""
     path_part, query_string = _split_path(path)
     host_str = raw_headers.get("host", "localhost")
     server_name, server_port = _parse_host_header(host_str)
+
+    remote_ip = "127.0.0.1"
+    trusted_client = _client_from_caddy_snake_headers(raw_headers)
+    if trusted_client is not None:
+        remote_ip = trusted_client[0]
 
     environ = {
         "REQUEST_METHOD": method,
@@ -371,8 +399,8 @@ def _build_wsgi_environ(method, path, version, headers_list, raw_headers, wsgi_i
         "SERVER_NAME": server_name,
         "SERVER_PORT": str(server_port),
         "SERVER_PROTOCOL": version,
-        "REMOTE_ADDR": "127.0.0.1",
-        "REMOTE_HOST": "127.0.0.1",
+        "REMOTE_ADDR": remote_ip,
+        "REMOTE_HOST": remote_ip,
         "X_FROM": "caddy-snake",
         "wsgi.version": (1, 0),
         "wsgi.url_scheme": "http",
@@ -394,7 +422,13 @@ def _build_wsgi_environ(method, path, version, headers_list, raw_headers, wsgi_i
     for h_name_bytes, h_value_bytes in headers_list:
         key = h_name_bytes.decode("latin-1")
         key_upper = key.upper().replace("-", "_")
-        if key_upper in ("CONTENT_TYPE", "CONTENT_LENGTH", "PROXY"):
+        if key_upper in (
+            "CONTENT_TYPE",
+            "CONTENT_LENGTH",
+            "PROXY",
+            "CADDY_SNAKE_REMOTE_ADDR",
+            "CADDY_SNAKE_REMOTE_PORT",
+        ):
             continue
         http_key = "HTTP_" + key_upper
         if http_key not in header_groups:
@@ -1043,6 +1077,18 @@ async def _handle_asgi_connection(reader, writer, app, state):
             host_str = raw_headers.get("host", "localhost")
             server_host, server_port = _parse_host_header(host_str)
 
+            headers_for_scope = [
+                (n, v)
+                for n, v in headers
+                if n not in (b"caddy-snake-remote-addr", b"caddy-snake-remote-port")
+            ]
+            trusted_client = _client_from_caddy_snake_headers(raw_headers)
+            if trusted_client is not None:
+                client_host, client_port = trusted_client
+                client_tp = (client_host, client_port)
+            else:
+                client_tp = ("127.0.0.1", 0)
+
             if is_websocket:
                 conn_type = "websocket"
                 scheme = "ws"
@@ -1060,9 +1106,9 @@ async def _handle_asgi_connection(reader, writer, app, state):
                 "query_string": query_string.encode("latin-1"),
                 "root_path": "",
                 "scheme": scheme,
-                "headers": headers,
+                "headers": headers_for_scope,
                 "server": (server_host, server_port),
-                "client": ("127.0.0.1", 0),
+                "client": client_tp,
             }
 
             if state is not None:

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -3,11 +3,13 @@ package caddysnake
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
 	"os"
 	"os/exec"
@@ -1782,5 +1784,67 @@ func TestPythonWorkerGroup_LoadsAndServesASGI(t *testing.T) {
 	}
 	if !bytes.Contains(body, []byte("Hello from ASGI")) {
 		t.Errorf("expected body to contain 'Hello from ASGI', got: %s", body)
+	}
+}
+
+func TestSetPythonWorkerOutboundHeaders_XForwardedChainAndTrusted(t *testing.T) {
+	inReq := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
+	inReq.RemoteAddr = "203.0.113.5:12345"
+	inReq.Header.Set("X-Forwarded-For", "198.51.100.1")
+
+	outReq := inReq.Clone(context.Background())
+	pr := &httputil.ProxyRequest{In: inReq, Out: outReq}
+	setPythonWorkerOutboundHeaders(pr, "127.0.0.1:9999")
+
+	if got := pr.Out.Header.Get("X-Forwarded-For"); got != "198.51.100.1, 203.0.113.5" {
+		t.Fatalf("X-Forwarded-For = %q, want %q", got, "198.51.100.1, 203.0.113.5")
+	}
+	if got := pr.Out.Header.Get(caddySnakeRemoteAddrHeader); got != "203.0.113.5" {
+		t.Fatalf("Caddy-Snake-Remote-Addr = %q", got)
+	}
+	if got := pr.Out.Header.Get(caddySnakeRemotePortHeader); got != "12345" {
+		t.Fatalf("Caddy-Snake-Remote-Port = %q", got)
+	}
+	if pr.Out.URL.String() != "http://127.0.0.1:9999/foo" {
+		t.Fatalf("out URL = %s", pr.Out.URL.String())
+	}
+}
+
+func TestSetPythonWorkerOutboundHeaders_NoPriorXFFIPv6(t *testing.T) {
+	inReq := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	inReq.RemoteAddr = "[2001:db8::1]:49322"
+	inReq.TLS = &tls.ConnectionState{} // emulate TLS for SetXForwarded proto
+
+	outReq := inReq.Clone(context.Background())
+	setPythonWorkerOutboundHeaders(&httputil.ProxyRequest{In: inReq, Out: outReq}, "/tmp/sock")
+
+	if got := outReq.Header.Get("X-Forwarded-For"); got != "2001:db8::1" {
+		t.Fatalf("X-Forwarded-For = %q", got)
+	}
+	if got := outReq.Header.Get(caddySnakeRemoteAddrHeader); got != "2001:db8::1" {
+		t.Fatalf("Caddy-Snake-Remote-Addr = %q", got)
+	}
+	if got := outReq.Header.Get(caddySnakeRemotePortHeader); got != "49322" {
+		t.Fatalf("Caddy-Snake-Remote-Port = %q", got)
+	}
+	if outReq.Header.Get("X-Forwarded-Proto") != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q", outReq.Header.Get("X-Forwarded-Proto"))
+	}
+}
+
+func TestSetPythonWorkerOutboundHeaders_StripsSpoofedTrustedHeaders(t *testing.T) {
+	inReq := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	inReq.RemoteAddr = "192.0.2.1:80"
+	inReq.Header.Set(caddySnakeRemoteAddrHeader, "6.6.6.6")
+	inReq.Header.Set(caddySnakeRemotePortHeader, "99999")
+
+	outReq := inReq.Clone(context.Background())
+	setPythonWorkerOutboundHeaders(&httputil.ProxyRequest{In: inReq, Out: outReq}, "127.0.0.1:1")
+
+	if got := outReq.Header.Get(caddySnakeRemoteAddrHeader); got != "192.0.2.1" {
+		t.Fatalf("trusted addr after spoof strip = %q", got)
+	}
+	if got := outReq.Header.Get(caddySnakeRemotePortHeader); got != "80" {
+		t.Fatalf("trusted port after spoof strip = %q", got)
 	}
 }

--- a/caddysnake_test.py
+++ b/caddysnake_test.py
@@ -886,6 +886,55 @@ class TestBuildWsgiEnviron:
         )
         assert "HTTP_PROXY" not in env
 
+    def test_trusted_remote_headers_set_remote_addr(self):
+        headers_list = [
+            (b"host", b"x"),
+            (b"caddy-snake-remote-addr", b"198.51.100.2"),
+            (b"caddy-snake-remote-port", b"9999"),
+            (b"x-forwarded-for", b"198.51.100.1"),
+        ]
+        raw_headers = {
+            "host": "x",
+            "caddy-snake-remote-addr": "198.51.100.2",
+            "caddy-snake-remote-port": "9999",
+            "x-forwarded-for": "198.51.100.1",
+        }
+        env = cs._build_wsgi_environ(
+            "GET", "/", "HTTP/1.1", headers_list, raw_headers, io.BytesIO(b"")
+        )
+        assert env["REMOTE_ADDR"] == "198.51.100.2"
+        assert env["REMOTE_HOST"] == "198.51.100.2"
+        assert env["HTTP_X_FORWARDED_FOR"] == "198.51.100.1"
+        assert "HTTP_CADDY_SNAKE_REMOTE_ADDR" not in env
+        assert "HTTP_CADDY_SNAKE_REMOTE_PORT" not in env
+
+    def test_trusted_remote_headers_invalid_ip_fallback(self):
+        raw_headers = {
+            "host": "x",
+            "caddy-snake-remote-addr": "not-an-ip",
+            "caddy-snake-remote-port": "443",
+        }
+        env = cs._build_wsgi_environ(
+            "GET", "/", "HTTP/1.1", [(b"host", b"x")], raw_headers, io.BytesIO(b"")
+        )
+        assert env["REMOTE_ADDR"] == "127.0.0.1"
+
+    def test_trusted_remote_bracketed_ipv6(self):
+        raw_headers = {
+            "host": "x",
+            "caddy-snake-remote-addr": "[::1]",
+            "caddy-snake-remote-port": "0",
+        }
+        env = cs._build_wsgi_environ(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            [(b"host", b"x"), (b"caddy-snake-remote-addr", b"[::1]")],
+            raw_headers,
+            io.BytesIO(b""),
+        )
+        assert env["REMOTE_ADDR"] == "::1"
+
 
 # ==================== WSGI Handler (async) ====================
 


### PR DESCRIPTION
## Summary

Fixes #168: WSGI `REMOTE_ADDR` / ASGI `client` were hard-coded to loopback.

## Changes

- **Go:** In `ReverseProxy.Rewrite`, restore inbound `X-Forwarded-For` and call `httputil.ProxyRequest.SetXForwarded()` (standard `X-Forwarded-For` chain plus Host/Proto). Set hop-authenticated `Caddy-Snake-Remote-Addr` / `Caddy-Snake-Remote-Port` from `RemoteAddr` after stripping any client-supplied values with those names.
- **Python:** Derive `REMOTE_ADDR` / ASGI `client` from validated `Caddy-Snake-Remote-*` only; pass `X-Forwarded-For` through as `HTTP_X_FORWARDED_FOR`; do not duplicate the custom headers in `HTTP_*` / ASGI scope headers.

## Tests

- Go: `TestSetPythonWorkerOutboundHeaders_*`
- Python: `TestBuildWsgiEnviron` cases for trusted headers / XFF / IPv6

## Note

If `RemoteAddr` at the Caddy handler is still `127.0.0.1` (e.g. extra proxy layer), Caddy trusted-proxy / client IP config may still be required; this fixes propagation from the handler into the embedded Python worker.

Made with [Cursor](https://cursor.com)