### PR TITLE
feat: ESGI support (module_esgi, gevent worker)

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   build:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -56,7 +56,7 @@ jobs:
           cd "$TMPDIR"
           caddysnake -t wsgi -a app:app -l :19080 -w 1 > caddy.log 2>&1 &
           CLI_PID=$!
-          timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" caddy.log; do sleep 1; done'
+          timeout 120 bash -c 'while ! grep -qE "finished cleaning storage units|serving initial configuration" caddy.log; do sleep 1; done'
           RESPONSE=$(curl -sf http://localhost:19080/)
           kill $CLI_PID 2>/dev/null || true
           wait $CLI_PID 2>/dev/null || true
@@ -77,7 +77,7 @@ jobs:
           cd "$TMPDIR"
           caddysnake -t asgi -a app:app -l :19081 -w 1 > caddy.log 2>&1 &
           CLI_PID=$!
-          timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" caddy.log; do sleep 1; done'
+          timeout 120 bash -c 'while ! grep -qE "finished cleaning storage units|serving initial configuration" caddy.log; do sleep 1; done'
           RESPONSE=$(curl -sf http://localhost:19081/)
           kill $CLI_PID 2>/dev/null || true
           wait $CLI_PID 2>/dev/null || true

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -12,6 +12,8 @@ permissions: {}
 
 jobs:
   embed-app:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/embed-app-tests.yml
+++ b/.github/workflows/embed-app-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
       - name: Choose architecture
         id: arch
         run: |
@@ -53,7 +53,7 @@ jobs:
         working-directory: cmd/embed-app
         run: |
           ./embed-test --listen 127.0.0.1:9080 > embed.log 2>&1 &
-          timeout 60 bash -c 'while ! grep -q "finished cleaning storage units" embed.log 2>/dev/null; do sleep 1; done'
+          timeout 120 bash -c 'while ! grep -qE "finished cleaning storage units|serving initial configuration" embed.log 2>/dev/null; do sleep 1; done'
           for i in $(seq 1 60); do
             RESPONSE=$(curl -s http://127.0.0.1:9080/ || true)
             if echo "$RESPONSE" | grep -q "Replace this placeholder"; then

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -52,6 +52,10 @@ jobs:
           - "dynamic"
         python-version: ["3.12", "3.13", "3.13t", "3.14"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
+        exclude:
+          # gevent/cffi cannot install on CPython 3.13 free-threaded (nogil); ESGI requires gevent
+          - tool-name: simple_esgi
+            python-version: "3.13t"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -47,6 +47,7 @@ jobs:
           - "fastapi"
           - "simple_autoreload"
           - "simple_async"
+          - "simple_esgi"
           - "socketio"
           - "dynamic"
         python-version: ["3.12", "3.13", "3.13t", "3.14"]
@@ -82,7 +83,7 @@ jobs:
           python main_test.py
       - name: Run integration tests (nogil)
         working-directory: tests/${{ matrix.tool-name }}/
-        if: matrix.python-version == '3.13t' && matrix.tool-name != 'flask'
+        if: matrix.python-version == '3.13t' && matrix.tool-name != 'flask' && matrix.tool-name != 'simple_esgi'
         continue-on-error: true
         run: |
           ./caddy run --config Caddyfile > caddy.log 2>&1 &

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .python-version
 venv
 .venv
+.pytest-venv
 
 # Build artifacts
 buildenv*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ For full CI-like integration tests without local Python/venv setup:
 ./tests/integration.sh fastapi 3.13
 ```
 
-Valid tools: `django`, `django_channels`, `flask`, `fastapi`, `simple_autoreload`, `simple_async`, `socketio`, `dynamic`  
+Valid tools: `django`, `django_channels`, `flask`, `fastapi`, `simple_autoreload`, `simple_async`, `simple_esgi`, `socketio`, `dynamic`  
 Valid Python versions: `3.12`, `3.13`, `3.13-nogil`, `3.14`
 
 Requires **Docker** (linux/amd64 container).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To make it easier to get started you can also grab one of the precompiled binari
 
 ## Features
 
-- **WSGI & ASGI support** — serve any Python web framework (Flask, Django, FastAPI, Starlette, etc.)
+- **WSGI, ASGI & ESGI** — serve WSGI and ASGI frameworks, plus [ESGI](https://github.com/mliezun/esgi) apps (blocking `application(scope, protocol)` per connection)
 - **Multi-worker** — process-based (default) or thread-based workers for concurrent request handling
 - **Auto-reload** — watches `.py` files and hot-reloads your app on changes during development
 - **Dynamic module loading** — use Caddy placeholders to load different apps per subdomain or route
@@ -47,14 +47,14 @@ The easiest way to get started on Linux is to download a pre-compiled Caddy bina
 # Start a WSGI server
 ./caddy python-server --server-type wsgi --app main:app
 
-# Start an ASGI server
-./caddy python-server --server-type asgi --app main:app
+# Start an ESGI server
+./caddy python-server --server-type esgi --app main:application
 ```
 
 This starts a server on port `9080` serving your app. See `./caddy python-server --help` for all options:
 
 ```
---server-type wsgi|asgi   Required. Type of Python app
+--server-type wsgi|asgi|esgi   Required. Type of Python app
 --app <module:var>        Required. Python module and app variable (e.g. main:app)
 --domain <example.com>    Enable HTTPS with automatic certificates
 --listen <addr>           Custom listen address (default: :9080)
@@ -67,6 +67,7 @@ This starts a server on port `9080` serving your app. See `./caddy python-server
 --debug                   Enable debug logging
 --access-logs             Enable access logs
 --lifespan on|off         Enable ASGI lifespan events (default: off)
+--runtime <name>           WSGI: sync|gevent; ESGI: gevent only; ASGI: native|uvloop (see docs)
 --autoreload              Watch .py files and reload on changes
 ```
 
@@ -128,6 +129,38 @@ See [Apps as Standalone Binaries](https://caddy-snake.readthedocs.io/en/latest/d
 ---
 
 ## Usage examples
+
+### ESGI (experimental)
+
+Caddy Snake can serve **[ESGI](https://github.com/mliezun/esgi)** applications — synchronous gateway apps with one invocation per HTTP or WebSocket connection and blocking I/O on a `protocol` object (see the [protocol draft](https://github.com/mliezun/esgi/blob/main/PROTOCOL.md)). **`module_esgi` uses gevent only** (no asyncio in the ESGI worker). For **`module_wsgi` / `module_asgi`**, see the **`runtime`** row in the table below (`native` / **`uvloop`** apply only to ASGI).
+
+`main.py` (sketch)
+
+```python
+def application(scope, protocol):
+    if scope["proto"] == "http":
+        body = protocol.read_body()
+        protocol.response_bytes(200, [("Content-Type", "text/plain")], b"ok")
+    elif scope["proto"] == "ws":
+        ws = protocol.accept()
+        ...
+        protocol.close()
+```
+
+`Caddyfile`
+
+```caddyfile
+http://localhost:9080 {
+    route {
+        python {
+            module_esgi "main:application"
+            runtime gevent
+        }
+    }
+}
+```
+
+See the [ESGI integration](https://caddy-snake.readthedocs.io/en/latest/docs/esgi) doc for the roadmap, `runtime` semantics, and how this relates to WSGI/ASGI.
 
 ### Flask (WSGI)
 
@@ -210,8 +243,10 @@ The `python` directive supports the following subdirectives:
 
 ```Caddyfile
 python {
-    module_wsgi "module:variable"       # WSGI app to serve (e.g. "main:app")
-    module_asgi "module:variable"       # ASGI app to serve (e.g. "main:app")
+    module_wsgi "module:variable"       # WSGI app (e.g. "main:app")
+    module_asgi "module:variable"       # ASGI app (e.g. "main:app")
+    module_esgi "module:variable"       # ESGI app (gevent worker; requires gevent installed)
+    runtime sync|gevent|native|uvloop   # See table; ESGI allows gevent only
     venv "/path/to/venv"                # Virtual environment path
     working_dir "/path/to/app"          # Working directory for module resolution
     workers 4                           # Number of worker processes (default: CPU count)
@@ -220,7 +255,7 @@ python {
 }
 ```
 
-You must specify either `module_wsgi` or `module_asgi` (not both).
+You must specify exactly one of `module_wsgi`, `module_asgi`, or `module_esgi`.
 
 ### `module_wsgi`
 
@@ -229,6 +264,24 @@ The Python module and WSGI application variable to import, in `"module:variable"
 ### `module_asgi`
 
 The Python module and ASGI application variable to import, in `"module:variable"` format.
+
+### `module_esgi`
+
+The Python module and ESGI application callable to import (`def application(scope, protocol): ...` or `__esgi__`), in `"module:variable"` format. See [ESGI](https://caddy-snake.readthedocs.io/en/latest/docs/esgi).
+
+### `runtime`
+
+Selects how the Python worker schedules work at the gateway boundary:
+
+| Interface | Allowed values | Default (when omitted) |
+| --- | --- | --- |
+| `module_wsgi` | `sync`, `gevent` | `sync` |
+| `module_esgi` | **`gevent`** only | `gevent` |
+| `module_asgi` | `native`, `uvloop` | `uvloop` |
+
+`native` uses the standard `asyncio` loop. **`uvloop`** selects the [uvloop](https://github.com/MagicStack/uvloop) event loop when the package is installed (with a warning and fallback to native asyncio if it is not). For **WSGI**, **`gevent`** is still the thread-pool compatibility mode unless/until a dedicated gevent stack is added. **ESGI** always runs the **gevent** `StreamServer` stack on plain sockets (install **`gevent`** in your app environment).
+
+**ESGI:** application code is synchronous (`def` + blocking `protocol` methods). The **ESGI Python subprocess does not use asyncio** for the Go-facing socket; it uses **gevent** only.
 
 ### `venv`
 

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -790,6 +790,7 @@ Ensure DNS A/AAAA records are correctly set up if using a public domain for secu
 			cmd.Flags().String("static-route", "/static", "Route to serve the static directory: /static")
 			cmd.Flags().Bool("debug", false, "Enable debug logs")
 			cmd.Flags().Bool("access-logs", false, "Enable access logs")
+			cmd.Flags().Bool("autoreload", false, "Watch .py files and reload on changes")
 			cmd.Flags().String("lifespan", "off", "Enable ASGI lifespan support (ignored in WSGI mode)")
 			cmd.Flags().String("runtime", "", "Worker runtime (wsgi: sync|gevent; esgi: gevent only; asgi: native|uvloop); defaults: sync for WSGI, gevent for ESGI, uvloop for ASGI")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(pythonServer)

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -79,6 +79,8 @@ type AppServer interface {
 type CaddySnake struct {
 	ModuleWsgi string `json:"module_wsgi,omitempty"`
 	ModuleAsgi string `json:"module_asgi,omitempty"`
+	ModuleEsgi string `json:"module_esgi,omitempty"`
+	Runtime    string `json:"runtime,omitempty"`
 	Lifespan   string `json:"lifespan,omitempty"`
 	WorkingDir string `json:"working_dir,omitempty"`
 	VenvPath   string `json:"venv_path,omitempty"`
@@ -87,6 +89,45 @@ type CaddySnake struct {
 	PythonPath string `json:"python_path,omitempty"`
 	logger     *zap.Logger
 	app        AppServer
+}
+
+// effectivePythonRuntime returns the runtime string passed to the Python worker.
+// When Runtime is empty: sync for WSGI, gevent for ESGI, uvloop for ASGI.
+func effectivePythonRuntime(iface, runtime string) string {
+	if iface == "asgi" && runtime == "libuv" {
+		runtime = "uvloop" // legacy alias; configuration name is uvloop
+	}
+	if runtime != "" {
+		return runtime
+	}
+	if iface == "asgi" {
+		return "uvloop"
+	}
+	if iface == "esgi" {
+		return "gevent"
+	}
+	return "sync"
+}
+
+func validatePythonRuntime(iface, runtime string) error {
+	eff := effectivePythonRuntime(iface, runtime)
+	switch iface {
+	case "wsgi":
+		if eff != "sync" && eff != "gevent" {
+			return fmt.Errorf("wsgi runtime must be sync or gevent, got %q", eff)
+		}
+	case "esgi":
+		if eff != "gevent" {
+			return fmt.Errorf("esgi runtime must be gevent, got %q", eff)
+		}
+	case "asgi":
+		if eff != "native" && eff != "uvloop" {
+			return fmt.Errorf("asgi runtime must be native or uvloop, got %q", eff)
+		}
+	default:
+		return fmt.Errorf("unknown python interface %q", iface)
+	}
+	return nil
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
@@ -102,9 +143,17 @@ func (f *CaddySnake) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					if !d.Args(&f.ModuleAsgi) {
 						return d.Errf("expected exactly one argument for module_asgi")
 					}
+				case "module_esgi":
+					if !d.Args(&f.ModuleEsgi) {
+						return d.Errf("expected exactly one argument for module_esgi")
+					}
 				case "module_wsgi":
 					if !d.Args(&f.ModuleWsgi) {
 						return d.Errf("expected exactly one argument for module_wsgi")
+					}
+				case "runtime":
+					if !d.Args(&f.Runtime) {
+						return d.Errf("expected exactly one argument for runtime")
 					}
 				case "lifespan":
 					if !d.Args(&f.Lifespan) || (f.Lifespan != "on" && f.Lifespan != "off") {
@@ -157,6 +206,7 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 	}
 
 	isDynamic := containsPlaceholder(f.ModuleWsgi) || containsPlaceholder(f.ModuleAsgi) ||
+		containsPlaceholder(f.ModuleEsgi) ||
 		containsPlaceholder(f.WorkingDir) || containsPlaceholder(f.VenvPath)
 
 	if isDynamic {
@@ -166,22 +216,34 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 	pythonBin := resolvePythonInterpreter(f.PythonPath, f.VenvPath)
 
 	if f.ModuleWsgi != "" {
-		f.app, err = NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, workers, pythonBin)
+		rt := effectivePythonRuntime("wsgi", f.Runtime)
+		f.app, err = NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin)
 		if err != nil {
 			return err
 		}
 		if f.Lifespan != "" {
 			f.logger.Warn("lifespan attribute is ignored in WSGI mode", zap.String("lifespan", f.Lifespan))
 		}
-		f.logger.Info("serving wsgi app", zap.String("module_wsgi", f.ModuleWsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin))
+		f.logger.Info("serving wsgi app", zap.String("module_wsgi", f.ModuleWsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
 	} else if f.ModuleAsgi != "" {
-		f.app, err = NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, workers, pythonBin)
+		rt := effectivePythonRuntime("asgi", f.Runtime)
+		f.app, err = NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin)
 		if err != nil {
 			return err
 		}
-		f.logger.Info("serving asgi app", zap.String("module_asgi", f.ModuleAsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin))
+		f.logger.Info("serving asgi app", zap.String("module_asgi", f.ModuleAsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
+	} else if f.ModuleEsgi != "" {
+		rt := effectivePythonRuntime("esgi", f.Runtime)
+		f.app, err = NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin)
+		if err != nil {
+			return err
+		}
+		if f.Lifespan != "" {
+			f.logger.Warn("lifespan is for ASGI only; ignored in ESGI mode", zap.String("lifespan", f.Lifespan))
+		}
+		f.logger.Info("serving esgi app", zap.String("module_esgi", f.ModuleEsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
 	} else {
-		return errors.New("asgi or wsgi app needs to be specified")
+		return errors.New("a wsgi, asgi, or esgi app must be specified")
 	}
 
 	if f.Autoreload == "on" {
@@ -196,12 +258,19 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 
 		var factory func() (AppServer, error)
 		if f.ModuleWsgi != "" {
+			rt := effectivePythonRuntime("wsgi", f.Runtime)
 			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, workers, pythonBin)
+				return NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin)
+			}
+		} else if f.ModuleAsgi != "" {
+			rt := effectivePythonRuntime("asgi", f.Runtime)
+			factory = func() (AppServer, error) {
+				return NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin)
 			}
 		} else {
+			rt := effectivePythonRuntime("esgi", f.Runtime)
 			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, workers, pythonBin)
+				return NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin)
 			}
 		}
 
@@ -216,16 +285,17 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 }
 
 // provisionDynamic sets up the module in dynamic mode where Caddy placeholders
-// in module_wsgi/module_asgi, working_dir, or venv are resolved per-request.
+// in module_wsgi/module_asgi/module_esgi, working_dir, or venv are resolved per-request.
 func (f *CaddySnake) provisionDynamic(workers int) error {
 	autoreload := f.Autoreload == "on"
 	pythonPath := f.PythonPath
 
 	if f.ModuleWsgi != "" {
 		lifespan := f.Lifespan
+		rt := effectivePythonRuntime("wsgi", f.Runtime)
 		factory := func(module, dir, venv string) (AppServer, error) {
 			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("wsgi", module, dir, venv, lifespan, workers, pythonBin)
+			return NewPythonWorkerGroup("wsgi", module, dir, venv, lifespan, rt, workers, pythonBin)
 		}
 		var err error
 		f.app, err = NewDynamicApp(f.ModuleWsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
@@ -242,9 +312,10 @@ func (f *CaddySnake) provisionDynamic(workers int) error {
 		)
 	} else if f.ModuleAsgi != "" {
 		lifespan := f.Lifespan
+		rt := effectivePythonRuntime("asgi", f.Runtime)
 		factory := func(module, dir, venv string) (AppServer, error) {
 			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("asgi", module, dir, venv, lifespan, workers, pythonBin)
+			return NewPythonWorkerGroup("asgi", module, dir, venv, lifespan, rt, workers, pythonBin)
 		}
 		var err error
 		f.app, err = NewDynamicApp(f.ModuleAsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
@@ -256,19 +327,57 @@ func (f *CaddySnake) provisionDynamic(workers int) error {
 			zap.String("working_dir", f.WorkingDir),
 			zap.String("venv_path", f.VenvPath),
 		)
+	} else if f.ModuleEsgi != "" {
+		rt := effectivePythonRuntime("esgi", f.Runtime)
+		factory := func(module, dir, venv string) (AppServer, error) {
+			pythonBin := resolvePythonInterpreter(pythonPath, venv)
+			return NewPythonWorkerGroup("esgi", module, dir, venv, "", rt, workers, pythonBin)
+		}
+		var err error
+		f.app, err = NewDynamicApp(f.ModuleEsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
+		if err != nil {
+			return err
+		}
+		if f.Lifespan != "" {
+			f.logger.Warn("lifespan is for ASGI only; ignored in dynamic ESGI mode", zap.String("lifespan", f.Lifespan))
+		}
+		f.logger.Info("serving dynamic esgi app",
+			zap.String("module_esgi", f.ModuleEsgi),
+			zap.String("working_dir", f.WorkingDir),
+			zap.String("venv_path", f.VenvPath),
+		)
 	} else {
-		return errors.New("asgi or wsgi app needs to be specified")
+		return errors.New("a wsgi, asgi, or esgi app must be specified for dynamic mode")
 	}
 	return nil
 }
 
 // Validate implements caddy.Validator.
 func (m *CaddySnake) Validate() error {
-	if m.ModuleWsgi != "" && m.ModuleAsgi != "" {
-		return errors.New("cannot specify both module_wsgi and module_asgi")
+	n := 0
+	if m.ModuleWsgi != "" {
+		n++
 	}
-	if m.ModuleWsgi == "" && m.ModuleAsgi == "" {
-		return errors.New("one of module_wsgi or module_asgi is required")
+	if m.ModuleAsgi != "" {
+		n++
+	}
+	if m.ModuleEsgi != "" {
+		n++
+	}
+	if n != 1 {
+		return errors.New("exactly one of module_wsgi, module_asgi, or module_esgi is required")
+	}
+	var iface string
+	switch {
+	case m.ModuleWsgi != "":
+		iface = "wsgi"
+	case m.ModuleAsgi != "":
+		iface = "asgi"
+	default:
+		iface = "esgi"
+	}
+	if err := validatePythonRuntime(iface, m.Runtime); err != nil {
+		return err
 	}
 	if m.Workers != "" {
 		w, err := strconv.Atoi(m.Workers)
@@ -386,6 +495,7 @@ type PythonWorker struct {
 	WorkingDir string
 	Venv       string
 	Lifespan   string
+	Runtime    string
 	PythonBin  string
 	Socket     *os.File
 	SockDir    string // private directory containing the socket (Unix only)
@@ -398,7 +508,7 @@ type PythonWorker struct {
 	Proxy     *httputil.ReverseProxy
 }
 
-func NewPythonWorker(iface, app, workingDir, venv, lifespan, pythonBin, scriptPath string) (*PythonWorker, error) {
+func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBin, scriptPath string) (*PythonWorker, error) {
 	var socket *os.File
 	var sockDir string
 	var err error
@@ -437,6 +547,7 @@ func NewPythonWorker(iface, app, workingDir, venv, lifespan, pythonBin, scriptPa
 		WorkingDir: workingDir,
 		Venv:       venv,
 		Lifespan:   lifespan,
+		Runtime:    pyRuntime,
 		PythonBin:  pythonBin,
 		Socket:     socket,
 		SockDir:    sockDir,
@@ -485,6 +596,9 @@ func (w *PythonWorker) Start() error {
 	}
 	if w.Lifespan != "" {
 		args = append(args, "--lifespan", w.Lifespan)
+	}
+	if w.Runtime != "" {
+		args = append(args, "--runtime", w.Runtime)
 	}
 
 	w.Cmd = exec.Command(w.PythonBin, args...)
@@ -599,7 +713,7 @@ type PythonWorkerGroup struct {
 	ScriptPath string
 }
 
-func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan string, count int, pythonBin string) (*PythonWorkerGroup, error) {
+func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string, count int, pythonBin string) (*PythonWorkerGroup, error) {
 	scriptPath, err := writeCaddysnakePy()
 	if err != nil {
 		return nil, fmt.Errorf("failed to write caddysnake.py: %w", err)
@@ -608,7 +722,7 @@ func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan string, count i
 	errs := make([]error, count)
 	workers := make([]*PythonWorker, count)
 	for i := 0; i < count; i++ {
-		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, pythonBin, scriptPath)
+		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, runtime, pythonBin, scriptPath)
 	}
 	wg := &PythonWorkerGroup{
 		Workers:    workers,
@@ -648,10 +762,11 @@ func init() {
 	httpcaddyfile.RegisterHandlerDirective("python", parsePythonDirective)
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name: "python-server",
-		Usage: "--server-type wsgi|asgi --app <module> " +
+		Usage: "--server-type wsgi|asgi|esgi --app <module> " +
 			"[--domain <example.com>] [--listen <addr>] [--workers <count>] " +
 			"[--python-path <path>] [--working-dir <path>] [--venv <path>] " +
 			"[--static-path <path>] [--static-route <route>] " +
+			"[--runtime <name>] " +
 			"[--debug] [--access-logs] [--autoreload]",
 		Short: "Spins up a Python server",
 		Long: `
@@ -663,7 +778,7 @@ Providing a domain name with the '--domain' flag enables HTTPS and sets the list
 Ensure DNS A/AAAA records are correctly set up if using a public domain for secure connections.
 `,
 		CobraFunc: func(cmd *cobra.Command) {
-			cmd.Flags().StringP("server-type", "t", "", "Required. The type of server to use: wsgi|asgi")
+			cmd.Flags().StringP("server-type", "t", "", "Required. The type of server to use: wsgi|asgi|esgi")
 			cmd.Flags().StringP("app", "a", "", "Required. App module to be imported")
 			cmd.Flags().StringP("domain", "d", "", "Domain name at which to serve the files")
 			cmd.Flags().StringP("listen", "l", "", "The address to which to bind the listener")
@@ -676,7 +791,7 @@ Ensure DNS A/AAAA records are correctly set up if using a public domain for secu
 			cmd.Flags().Bool("debug", false, "Enable debug logs")
 			cmd.Flags().Bool("access-logs", false, "Enable access logs")
 			cmd.Flags().String("lifespan", "off", "Enable ASGI lifespan support (ignored in WSGI mode)")
-			cmd.Flags().Bool("autoreload", false, "Watch .py files and reload on changes")
+			cmd.Flags().String("runtime", "", "Worker runtime (wsgi: sync|gevent; esgi: gevent only; asgi: native|uvloop); defaults: sync for WSGI, gevent for ESGI, uvloop for ASGI")
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(pythonServer)
 		},
 	})
@@ -700,9 +815,13 @@ func pythonServer(fs caddycmd.Flags) (int, error) {
 	workingDir := fs.String("working-dir")
 	venv := fs.String("venv")
 	lifespan := fs.String("lifespan")
+	runtimeFlag := fs.String("runtime")
 
 	if serverType == "" {
 		return caddy.ExitCodeFailedStartup, errors.New("--server-type is required")
+	}
+	if serverType != "wsgi" && serverType != "asgi" && serverType != "esgi" {
+		return caddy.ExitCodeFailedStartup, fmt.Errorf("invalid --server-type %q (want wsgi, asgi, or esgi)", serverType)
 	}
 	if app == "" {
 		return caddy.ExitCodeFailedStartup, errors.New("--app is required")
@@ -727,8 +846,10 @@ func pythonServer(fs caddycmd.Flags) (int, error) {
 	pythonHandler := CaddySnake{}
 	if serverType == "wsgi" {
 		pythonHandler.ModuleWsgi = app
-	} else {
+	} else if serverType == "asgi" {
 		pythonHandler.ModuleAsgi = app
+	} else {
+		pythonHandler.ModuleEsgi = app
 	}
 	if venv != "" {
 		pythonHandler.VenvPath = venv
@@ -743,6 +864,11 @@ func pythonServer(fs caddycmd.Flags) (int, error) {
 	}
 	pythonHandler.WorkingDir = workingDir
 	pythonHandler.Lifespan = lifespan
+	pythonHandler.Runtime = runtimeFlag
+
+	if err := pythonHandler.Validate(); err != nil {
+		return caddy.ExitCodeFailedStartup, err
+	}
 
 	routes := caddyhttp.RouteList{}
 

--- a/caddysnake.py
+++ b/caddysnake.py
@@ -7,7 +7,7 @@ Designed to be spawned as a subprocess by the caddy-snake Go module.
 
 Usage:
     python caddysnake.py --socket /path/to/sock --app module:variable \
-        --interface wsgi|asgi [--working-dir DIR] [--venv DIR] [--lifespan on|off]
+        --interface wsgi|asgi|esgi [--working-dir DIR] [--venv DIR] [--lifespan on|off] [--runtime NAME]
 """
 
 import argparse
@@ -572,8 +572,14 @@ async def _run_wsgi_server_async(app, socket_path):
         pass
 
 
-def run_wsgi_server(app, socket_path):
+def run_wsgi_server(app, socket_path, runtime: str = "sync"):
     """Run a WSGI server. On Unix: Unix socket at socket_path. On Windows: TCP, write port to socket_path."""
+    if runtime == "gevent":
+        print(
+            "Note: runtime=gevent uses the same thread-pool scheduling as sync until "
+            "native gevent integration lands.",
+            file=sys.stderr,
+        )
     asyncio.run(_run_wsgi_server_async(app, socket_path))
 
 
@@ -1057,6 +1063,713 @@ async def _handle_asgi_websocket(reader, writer, app, scope, raw_headers):
                 pass
 
 
+# ==================== ESGI Server (gevent, 0.1-draft) ====================
+# Specification: https://github.com/mliezun/esgi/blob/main/PROTOCOL.md
+#
+# ESGI is gevent-only: StreamServer + plain sockets + greenlets. No asyncio in this
+# worker mode. Each client connection runs in its own greenlet; apps are synchronous.
+
+
+def _configure_asgi_event_loop(runtime: str) -> None:
+    """Apply event loop policy before asyncio.run for ASGI workers."""
+    if runtime in ("uvloop", "libuv"):
+        try:
+            import uvloop
+
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        except ImportError:
+            print(
+                "warning: ASGI runtime is uvloop but uvloop is not installed; "
+                "falling back to native asyncio",
+                file=sys.stderr,
+            )
+    # native: standard asyncio loop
+
+
+def _recv_exact_sock(sock, n: int) -> bytes:
+    chunks = []
+    got = 0
+    while got < n:
+        b = sock.recv(n - got)
+        if not b:
+            raise OSError("connection closed while reading HTTP/WebSocket")
+        chunks.append(b)
+        got += len(b)
+    return b"".join(chunks)
+
+
+def _read_http_request_sync(sock):
+    """Blocking HTTP/1.x request parser; returns None on EOF/parse error."""
+    buf = bytearray()
+    while True:
+        if len(buf) > MAX_HEADERS_SIZE:
+            return None
+        sep = buf.find(b"\r\n\r\n")
+        if sep >= 0:
+            header_blob = bytes(buf[: sep + 4])
+            leftover = bytes(buf[sep + 4 :])
+            break
+        chunk = sock.recv(16384)
+        if not chunk:
+            return None
+        buf.extend(chunk)
+
+    lines = header_blob[:-4].split(b"\r\n")
+    if not lines or len(lines[0]) > MAX_REQUEST_LINE:
+        return None
+    request_line = lines[0].decode("latin-1")
+    parts = request_line.split(" ", 2)
+    if len(parts) != 3:
+        return None
+    method, path, version = parts
+
+    if len(lines) - 1 > MAX_HEADER_COUNT:
+        return None
+
+    headers = []
+    raw_headers = {}
+    for line in lines[1:]:
+        colon = line.find(b":")
+        if colon < 0:
+            continue
+        name = line[:colon].strip().lower()
+        value = line[colon + 1 :].strip()
+        headers.append((name, value))
+        raw_headers[name.decode("latin-1")] = value.decode("latin-1")
+
+    content_length = raw_headers.get("content-length")
+    transfer_encoding = raw_headers.get("transfer-encoding", "")
+    if content_length and transfer_encoding:
+        return None
+
+    if content_length:
+        try:
+            cl = int(content_length)
+        except ValueError:
+            return None
+        if cl < 0 or cl > MAX_BODY_SIZE:
+            return None
+        body_stream = _SyncHttpBodyStream(sock, leftover, content_length=cl)
+    elif "chunked" in transfer_encoding.lower():
+        body_stream = _SyncHttpBodyStream(sock, leftover, chunked=True)
+    else:
+        body_stream = _SyncHttpBodyStream(sock, leftover, content_length=0)
+
+    return method, path, version, headers, raw_headers, body_stream
+
+
+class _SyncHttpBodyStream:
+    """Blocking request body reader (Content-Length or chunked)."""
+
+    def __init__(self, sock, initial=b"", content_length=None, chunked=False):
+        self._sock = sock
+        self._buf = bytearray(initial)
+        self._remaining = content_length
+        self._chunked = chunked
+        self._chunk_remaining = 0
+        self._total_read = 0
+        self._done = (content_length == 0) and not chunked
+
+    def _bump_total(self, size):
+        if size <= 0:
+            return
+        self._total_read += size
+        if self._total_read > MAX_BODY_SIZE:
+            raise ValueError("HTTP request body too large")
+
+    def read(self, max_bytes=64 * 1024):
+        if self._done:
+            return b""
+        if max_bytes is None or max_bytes <= 0:
+            max_bytes = 64 * 1024
+
+        if self._remaining is not None:
+            if self._remaining <= 0:
+                self._done = True
+                return b""
+            to_read = min(max_bytes, self._remaining)
+            if len(self._buf) < to_read:
+                need = to_read - len(self._buf)
+                chunk = self._sock.recv(max(need, 4096))
+                if not chunk:
+                    raise OSError("unexpected EOF reading body")
+                self._buf.extend(chunk)
+            data = bytes(self._buf[:to_read])
+            del self._buf[:to_read]
+            self._bump_total(len(data))
+            self._remaining -= len(data)
+            if self._remaining == 0:
+                self._done = True
+            return data
+
+        if not self._chunked:
+            self._done = True
+            return b""
+
+        while True:
+            if self._chunk_remaining == 0:
+                line = self._readline_chunked()
+                if not line:
+                    raise OSError("EOF in chunked body")
+                if len(line) > MAX_REQUEST_LINE:
+                    raise ValueError("Chunk size line too long")
+                size_str = line.strip()
+                if b";" in size_str:
+                    size_str = size_str.split(b";", 1)[0]
+                try:
+                    chunk_size = int(size_str, 16)
+                except ValueError as exc:
+                    raise ValueError("Invalid chunk size") from exc
+                if chunk_size < 0:
+                    raise ValueError("Invalid negative chunk size")
+                if chunk_size == 0:
+                    while True:
+                        trailer_line = self._readline_chunked()
+                        if trailer_line in (b"\r\n", b"\n", b""):
+                            break
+                        if len(trailer_line) > MAX_REQUEST_LINE:
+                            raise ValueError("Chunk trailer line too long")
+                    self._done = True
+                    return b""
+                self._chunk_remaining = chunk_size
+
+            to_read = min(max_bytes, self._chunk_remaining)
+            if len(self._buf) < to_read:
+                need = to_read - len(self._buf)
+                chunk = self._sock.recv(max(need, 4096))
+                if not chunk:
+                    raise OSError("unexpected EOF in chunk")
+                self._buf.extend(chunk)
+            data = bytes(self._buf[:to_read])
+            del self._buf[:to_read]
+            self._bump_total(len(data))
+            self._chunk_remaining -= len(data)
+            if self._chunk_remaining == 0:
+                _recv_exact_sock(self._sock, 2)
+            if data:
+                return data
+
+    def _readline_chunked(self):
+        while True:
+            nl = self._buf.find(b"\n")
+            if nl >= 0:
+                line = bytes(self._buf[: nl + 1])
+                del self._buf[: nl + 1]
+                return line
+            chunk = self._sock.recv(4096)
+            if not chunk:
+                return b""
+            self._buf.extend(chunk)
+
+    def discard(self):
+        while True:
+            chunk = self.read()
+            if not chunk:
+                return
+
+
+def _esgi_http_version(req_version: str) -> str:
+    if "/" in req_version:
+        return req_version.split("/", 1)[1]
+    return "1.1"
+
+
+def _esgi_scheme_from_headers(raw_headers: dict) -> str:
+    xfp = raw_headers.get("x-forwarded-proto", "").lower().strip()
+    if xfp in ("https", "http"):
+        return xfp
+    return "http"
+
+
+def _esgi_ws_scheme_from_headers(raw_headers: dict) -> str:
+    return "wss" if _esgi_scheme_from_headers(raw_headers) == "https" else "ws"
+
+
+def _esgi_headers_mapping(headers_list, raw_headers: dict) -> dict:
+    headers_map = {}
+    for n, v in headers_list:
+        k = n.decode("latin-1").lower()
+        if k in ("caddy-snake-remote-addr", "caddy-snake-remote-port"):
+            continue
+        val = v.decode("latin-1")
+        if k in headers_map:
+            headers_map[k] = headers_map[k] + ", " + val
+        else:
+            headers_map[k] = val
+    return headers_map
+
+
+def _esgi_decode_path(path_part: str) -> str:
+    if "%" not in path_part:
+        return path_part
+    return unquote(path_part, encoding="utf-8", errors="replace")
+
+
+def _build_esgi_http_scope(method, path, version, headers_list, raw_headers: dict):
+    path_part, query_string = _split_path(path)
+    path_decoded = _esgi_decode_path(path_part)
+    host_str = raw_headers.get("host", "localhost")
+    server_host, server_port = _parse_host_header(host_str)
+    trusted = _client_from_caddy_snake_headers(raw_headers)
+    if trusted:
+        client_host, client_port = trusted
+    else:
+        client_host, client_port = "127.0.0.1", 0
+
+    return {
+        "proto": "http",
+        "esgi_version": "0.1",
+        "http_version": _esgi_http_version(version),
+        "server": f"{server_host}:{server_port}",
+        "client": f"{client_host}:{client_port}",
+        "scheme": _esgi_scheme_from_headers(raw_headers),
+        "method": method.upper(),
+        "path": path_decoded,
+        "query_string": query_string,
+        "headers": _esgi_headers_mapping(headers_list, raw_headers),
+        "authority": raw_headers.get("host") or None,
+    }
+
+
+def _build_esgi_ws_scope(method, path, version, headers_list, raw_headers: dict):
+    path_part, query_string = _split_path(path)
+    path_decoded = _esgi_decode_path(path_part)
+    host_str = raw_headers.get("host", "localhost")
+    server_host, server_port = _parse_host_header(host_str)
+    trusted = _client_from_caddy_snake_headers(raw_headers)
+    if trusted:
+        client_host, client_port = trusted
+    else:
+        client_host, client_port = "127.0.0.1", 0
+
+    return {
+        "proto": "ws",
+        "esgi_version": "0.1",
+        "http_version": _esgi_http_version(version),
+        "server": f"{server_host}:{server_port}",
+        "client": f"{client_host}:{client_port}",
+        "scheme": _esgi_ws_scheme_from_headers(raw_headers),
+        "method": method.upper(),
+        "path": path_decoded,
+        "query_string": query_string,
+        "headers": _esgi_headers_mapping(headers_list, raw_headers),
+        "authority": raw_headers.get("host") or None,
+    }
+
+
+class _EsgiWsMessage:
+    __slots__ = ("kind", "data")
+
+    def __init__(self, kind, data=None):
+        self.kind = kind
+        self.data = data
+
+
+def ws_read_frame_sync(sock):
+    data = _recv_exact_sock(sock, 2)
+    fin = (data[0] >> 7) & 1
+    opcode = data[0] & 0xF
+    masked = (data[1] >> 7) & 1
+    payload_len = data[1] & 0x7F
+
+    if payload_len == 126:
+        data = _recv_exact_sock(sock, 2)
+        payload_len = struct.unpack("!H", data)[0]
+    elif payload_len == 127:
+        data = _recv_exact_sock(sock, 8)
+        payload_len = struct.unpack("!Q", data)[0]
+
+    if payload_len > MAX_WS_FRAME_SIZE:
+        raise ValueError(f"WebSocket frame too large: {payload_len}")
+
+    mask_key = None
+    if masked:
+        mask_key = _recv_exact_sock(sock, 4)
+
+    payload = _recv_exact_sock(sock, payload_len) if payload_len > 0 else b""
+
+    if mask_key:
+        payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+
+    return fin, opcode, payload
+
+
+def _ws_close_frame_bytes(code: int) -> bytes:
+    payload = struct.pack("!H", code)
+    return ws_build_frame(WS_OPCODE_CLOSE, payload)
+
+
+def _esgi_ws_reader_greenlet(sock, msg_queue):
+    try:
+        while True:
+            fin, opcode, payload = ws_read_frame_sync(sock)
+            if opcode == WS_OPCODE_CLOSE:
+                code = 1005
+                if len(payload) >= 2:
+                    code = struct.unpack("!H", payload[:2])[0]
+                msg_queue.put(_EsgiWsMessage(0, code))
+                break
+            if opcode == WS_OPCODE_PING:
+                sock.sendall(ws_build_frame(WS_OPCODE_PONG, payload))
+                continue
+            if opcode == WS_OPCODE_PONG:
+                continue
+            if opcode == WS_OPCODE_TEXT:
+                if not fin:
+                    sock.sendall(_ws_close_frame_bytes(1003))
+                    msg_queue.put(_EsgiWsMessage(0, 1003))
+                    break
+                try:
+                    text = payload.decode("utf-8")
+                except UnicodeDecodeError:
+                    sock.sendall(_ws_close_frame_bytes(1007))
+                    msg_queue.put(_EsgiWsMessage(0, 1007))
+                    break
+                msg_queue.put(_EsgiWsMessage(2, text))
+            elif opcode == WS_OPCODE_BINARY:
+                if not fin:
+                    sock.sendall(_ws_close_frame_bytes(1003))
+                    msg_queue.put(_EsgiWsMessage(0, 1003))
+                    break
+                msg_queue.put(_EsgiWsMessage(1, payload))
+            else:
+                sock.sendall(_ws_close_frame_bytes(1002))
+                msg_queue.put(_EsgiWsMessage(0, 1002))
+                break
+    except (ValueError, OSError, ConnectionError):
+        msg_queue.put(_EsgiWsMessage(0, 1006))
+
+
+class _EsgiWsTransportSync:
+    def __init__(self, sock, msg_queue):
+        self._sock = sock
+        self._q = msg_queue
+
+    def receive(self):
+        return self._q.get()
+
+    def send_bytes(self, data: bytes) -> None:
+        self._sock.sendall(ws_build_frame(WS_OPCODE_BINARY, data))
+
+    def send_str(self, data: str) -> None:
+        self._sock.sendall(ws_build_frame(WS_OPCODE_TEXT, data.encode("utf-8")))
+
+
+class _EsgiWsRootProtocolSync:
+    def __init__(self, sock, raw_headers):
+        self._sock = sock
+        self._raw_headers = raw_headers
+        self._accepted = False
+        self._closed = False
+        self._reader = None
+        self._q = None
+
+    def accept(self):
+        if self._accepted:
+            raise RuntimeError("websocket already accepted")
+        import gevent.queue
+
+        ws_key = self._raw_headers.get("sec-websocket-key", "")
+        if not ws_key:
+            raise ValueError("missing Sec-WebSocket-Key")
+        accept_value = ws_accept_key(ws_key)
+        response = (
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Accept: {accept_value}\r\n\r\n"
+        )
+        self._sock.sendall(response.encode("latin-1"))
+        self._q = gevent.queue.Queue()
+        import gevent
+
+        self._reader = gevent.spawn(_esgi_ws_reader_greenlet, self._sock, self._q)
+        self._accepted = True
+        return _EsgiWsTransportSync(self._sock, self._q)
+
+    def close(self, code=None, reason=None) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if not self._accepted:
+            try:
+                self._sock.sendall(
+                    b"HTTP/1.1 403 Forbidden\r\nContent-Length: 13\r\n\r\n403 Forbidden"
+                )
+            except OSError:
+                pass
+            return
+        c = 1000 if code is None else int(code)
+        r = reason or ""
+        payload = struct.pack("!H", c) + r.encode("utf-8")
+        try:
+            self._sock.sendall(ws_build_frame(WS_OPCODE_CLOSE, payload))
+        except OSError:
+            pass
+        if self._reader is not None:
+            self._reader.kill(block=False)
+
+    def cleanup_after_app(self):
+        if self._reader is not None:
+            try:
+                if not self._reader.dead:
+                    self._reader.kill(block=False)
+            except Exception:
+                pass
+
+
+class _EsgiHttpProtocolSync:
+    def __init__(self, sock, body_stream):
+        self._sock = sock
+        self._body_stream = body_stream
+        self._responded = False
+        self._body_started = False
+
+    def _ensure_not_responded(self):
+        if self._responded:
+            raise RuntimeError("response already sent for this request")
+
+    def read_body(self) -> bytes:
+        if self._body_started:
+            raise RuntimeError("request body already consumed")
+        self._body_started = True
+        chunks = []
+        while True:
+            chunk = self._body_stream.read()
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    def iter_body(self):
+        if self._body_started:
+            raise RuntimeError("request body already consumed")
+        self._body_started = True
+
+        def gen():
+            while True:
+                chunk = self._body_stream.read()
+                if not chunk:
+                    break
+                yield chunk
+
+        return gen()
+
+    def _write_response(self, status, headers, body: bytes):
+        buf = bytearray(_get_status_line(status))
+        cl_present = False
+        for name, value in headers:
+            buf.extend(f"{name}: {value}\r\n".encode("latin-1"))
+            if name.lower() == "content-length":
+                cl_present = True
+        if not cl_present:
+            buf.extend(b"Content-Length: ")
+            buf.extend(str(len(body)).encode("ascii"))
+            buf.extend(b"\r\n")
+        buf.extend(b"\r\n")
+        buf.extend(body)
+        self._sock.sendall(bytes(buf))
+
+    def response_empty(self, status: int, headers: list) -> None:
+        self.response_bytes(status, headers, b"")
+
+    def response_str(self, status: int, headers: list, body: str) -> None:
+        self.response_bytes(status, headers, body.encode("utf-8"))
+
+    def response_bytes(self, status: int, headers: list, body: bytes) -> None:
+        self._ensure_not_responded()
+        self._responded = True
+        self._write_response(status, headers, body)
+
+    def response_file(self, status: int, headers: list, file) -> None:
+        path = os.fsdecode(file)
+        with open(path, "rb") as f:
+            data = f.read()
+        self.response_bytes(status, headers, data)
+
+    def response_file_range(
+        self, status: int, headers: list, file, start: int, end: int
+    ) -> None:
+        path = os.fsdecode(file)
+        with open(path, "rb") as f:
+            f.seek(start)
+            data = f.read(end - start)
+        self.response_bytes(status, headers, data)
+
+    def response_stream(self, status: int, headers: list):
+        raise NotImplementedError("ESGI response_stream is not implemented yet")
+
+    def wait_disconnect(self) -> None:
+        pass
+
+
+def _invoke_esgi_app(app, scope, protocol) -> None:
+    if hasattr(app, "__esgi__"):
+        app.__esgi__(scope, protocol)
+    else:
+        app(scope, protocol)
+
+
+def _handle_esgi_http_sync(
+    sock, app, method, path, version, headers_list, raw_headers, body_stream
+):
+    scope = _build_esgi_http_scope(method, path, version, headers_list, raw_headers)
+    protocol = _EsgiHttpProtocolSync(sock, body_stream)
+    try:
+        _invoke_esgi_app(app, scope, protocol)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        if not protocol._responded:
+            try:
+                protocol.response_bytes(
+                    500,
+                    [("Content-Type", "text/plain")],
+                    b"Internal Server Error",
+                )
+            except Exception:
+                pass
+    if not protocol._body_started:
+        body_stream.discard()
+
+
+def _handle_esgi_websocket_sync(
+    sock, app, raw_headers, headers_list, version, path, method
+):
+    scope = _build_esgi_ws_scope(method, path, version, headers_list, raw_headers)
+    ws_proto = _EsgiWsRootProtocolSync(sock, raw_headers)
+    try:
+        _invoke_esgi_app(app, scope, ws_proto)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        if not ws_proto._accepted:
+            try:
+                sock.sendall(
+                    b"HTTP/1.1 500 Internal Server Error\r\n"
+                    b"Content-Length: 21\r\n\r\n"
+                    b"Internal Server Error"
+                )
+            except OSError:
+                pass
+    finally:
+        ws_proto.cleanup_after_app()
+
+
+def _esgi_connection_loop(sock, app):
+    try:
+        while True:
+            result = _read_http_request_sync(sock)
+            if result is None:
+                return
+            method, path, version, headers_list, raw_headers, body_stream = result
+            is_websocket = (
+                method.upper() == "GET"
+                and raw_headers.get("upgrade", "").lower() == "websocket"
+                and "upgrade" in raw_headers.get("connection", "").lower()
+            )
+            if is_websocket:
+                body_stream.discard()
+                _handle_esgi_websocket_sync(
+                    sock, app, raw_headers, headers_list, version, path, method
+                )
+                return
+            _handle_esgi_http_sync(
+                sock, app, method, path, version, headers_list, raw_headers, body_stream
+            )
+            connection = raw_headers.get("connection", "")
+            if "close" in connection.lower():
+                return
+    except (OSError, ValueError, ConnectionError):
+        pass
+
+
+def run_esgi_server(app, socket_path: str, runtime: str):
+    if runtime != "gevent":
+        print("ESGI requires runtime gevent (no asyncio transport)", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        import gevent
+        import gevent.socket
+        from gevent.server import StreamServer
+    except ImportError:
+        print("ESGI requires gevent; pip install gevent", file=sys.stderr)
+        sys.exit(1)
+
+    import gevent.signal as gsig
+
+    if hasattr(app, "__esgi_init__"):
+        try:
+            app.__esgi_init__()
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            sys.exit(1)
+
+    def handle(sock, _addr):
+        try:
+            _esgi_connection_loop(sock, app)
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    server = None
+
+    try:
+        if _USE_TCP:
+            server = StreamServer(("127.0.0.1", 0), handle)
+        else:
+            if os.path.exists(socket_path):
+                os.unlink(socket_path)
+            listener_sock = gevent.socket.socket(
+                gevent.socket.AF_UNIX, gevent.socket.SOCK_STREAM
+            )
+            listener_sock.bind(socket_path)
+            listener_sock.listen(256)
+            server = StreamServer(listener_sock, handle)
+        server.start()
+
+        if _USE_TCP:
+            port = server.socket.getsockname()[1]
+            try:
+                _write_port_file_atomic(socket_path, port)
+            except OSError as e:
+                print(f"Failed to write port file: {e}", file=sys.stderr)
+                sys.exit(1)
+            print(f"ESGI server listening on 127.0.0.1:{port}", file=sys.stderr)
+        else:
+            print(f"ESGI server listening on {socket_path}", file=sys.stderr)
+
+        def _stop(*_args):
+            if server is not None:
+                try:
+                    server.close()
+                except Exception:
+                    pass
+
+        gsig.signal(signal.SIGTERM, _stop)
+        gsig.signal(signal.SIGINT, _stop)
+        server.serve_forever()
+    finally:
+        if hasattr(app, "__esgi_del__"):
+            try:
+                app.__esgi_del__()
+            except Exception:
+                traceback.print_exc(file=sys.stderr)
+        if server is not None:
+            try:
+                server.close()
+            except Exception:
+                pass
+        try:
+            if not _USE_TCP and os.path.exists(socket_path):
+                os.unlink(socket_path)
+        except OSError:
+            pass
+        sys.stderr.flush()
+        sys.stdout.flush()
+
+
 async def _handle_asgi_connection(reader, writer, app, state):
     """Handle a single TCP connection (supports keep-alive)."""
     try:
@@ -1287,26 +2000,28 @@ async def run_asgi_server(app, socket_path, lifespan):
 
 
 def main():
-    try:
-        import uvloop
-
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-    except ImportError:
-        pass
-
     parser = argparse.ArgumentParser(description="caddy-snake Python server")
-    parser.add_argument("--socket", required=True, help="Unix socket path")
+    parser.add_argument(
+        "--socket",
+        required=True,
+        help="Platform path: Unix socket path (Unix) or port file path (Windows)",
+    )
     parser.add_argument("--app", required=True, help="Application module:variable")
     parser.add_argument(
         "--interface",
         required=True,
-        choices=["wsgi", "asgi"],
+        choices=["wsgi", "asgi", "esgi"],
         help="Server interface type",
     )
     parser.add_argument("--working-dir", default="", help="Working directory")
     parser.add_argument("--venv", default="", help="Virtual environment path")
     parser.add_argument(
         "--lifespan", default="off", choices=["on", "off"], help="ASGI lifespan events"
+    )
+    parser.add_argument(
+        "--runtime",
+        default="",
+        help="Worker runtime: wsgi uses sync|gevent; esgi uses gevent only; asgi uses native|uvloop",
     )
 
     args = parser.parse_args()
@@ -1315,9 +2030,12 @@ def main():
     app = import_app(args.app)
 
     if args.interface == "wsgi":
-        run_wsgi_server(app, args.socket)
-    else:
+        run_wsgi_server(app, args.socket, args.runtime or "sync")
+    elif args.interface == "asgi":
+        _configure_asgi_event_loop(args.runtime or "uvloop")
         asyncio.run(run_asgi_server(app, args.socket, args.lifespan == "on"))
+    else:
+        run_esgi_server(app, args.socket, args.runtime or "gevent")
 
 
 if __name__ == "__main__":

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -1838,7 +1838,7 @@ func TestPythonWorkerGroup_LoadsAndServesESGI(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	skipIfNoPython(t)
+	skipIfNoGevent(t)
 
 	tempDir := t.TempDir()
 	appPath := filepath.Join(tempDir, "app.py")

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -423,7 +423,7 @@ func TestValidate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when neither wsgi nor asgi specified")
 	}
-	if !strings.Contains(err.Error(), "one of module_wsgi or module_asgi is required") {
+	if !strings.Contains(err.Error(), "exactly one of module_wsgi, module_asgi, or module_esgi is required") {
 		t.Errorf("expected module required error, got: %v", err)
 	}
 }
@@ -442,11 +442,43 @@ func TestValidate_AsgiOnly(t *testing.T) {
 	}
 }
 
+func TestValidate_EsgiOnly(t *testing.T) {
+	cs := &CaddySnake{ModuleEsgi: "main:app"}
+	if err := cs.Validate(); err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+func TestValidate_EsgiRequiresGevent(t *testing.T) {
+	cs := &CaddySnake{ModuleEsgi: "main:app", Runtime: "sync"}
+	err := cs.Validate()
+	if err == nil {
+		t.Fatal("expected error: esgi must use gevent runtime")
+	}
+}
+
+func TestValidate_InvalidRuntimeForAsgi(t *testing.T) {
+	cs := &CaddySnake{ModuleAsgi: "main:app", Runtime: "gevent"}
+	err := cs.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid asgi runtime")
+	}
+}
+
+func TestEffectivePythonRuntime_LibuvAlias(t *testing.T) {
+	if got := effectivePythonRuntime("asgi", "libuv"); got != "uvloop" {
+		t.Fatalf("legacy libuv alias: got %q want uvloop", got)
+	}
+}
+
 func TestValidate_BothModules(t *testing.T) {
 	cs := &CaddySnake{ModuleWsgi: "main:app", ModuleAsgi: "main:app"}
 	err := cs.Validate()
 	if err == nil {
-		t.Fatal("expected error when both modules specified")
+		t.Fatal("expected error when two modules specified")
+	}
+	if !strings.Contains(err.Error(), "exactly one of") {
+		t.Errorf("expected exactly one module error, got: %v", err)
 	}
 }
 
@@ -483,13 +515,13 @@ func TestProvision_NoModule(t *testing.T) {
 		t.Fatalf("ProvisionContext: %v", err)
 	}
 
-	cs := &CaddySnake{} // neither ModuleWsgi nor ModuleAsgi set
+	cs := &CaddySnake{} // no module set
 	err = cs.Provision(ctx)
 	if err == nil {
-		t.Fatal("expected error when neither wsgi nor asgi specified")
+		t.Fatal("expected error when neither wsgi nor asgi nor esgi specified")
 	}
-	if !strings.Contains(err.Error(), "asgi or wsgi") {
-		t.Errorf("expected 'asgi or wsgi' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "wsgi, asgi, or esgi") {
+		t.Errorf("expected module error in error, got: %v", err)
 	}
 }
 
@@ -1518,7 +1550,7 @@ func TestNewPythonWorkerGroup_InvalidPythonPath(t *testing.T) {
 	tempDir := t.TempDir()
 	os.WriteFile(filepath.Join(tempDir, "app.py"), []byte(minimalWSGIApp), 0644)
 
-	_, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", 1, "/nonexistent/python-not-found")
+	_, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "/nonexistent/python-not-found")
 	if err == nil {
 		t.Fatal("expected error when python path is invalid")
 	}
@@ -1541,7 +1573,7 @@ func TestPythonWorkerCleanup_Timeout(t *testing.T) {
 	tempDir := t.TempDir()
 	os.WriteFile(filepath.Join(tempDir, "app.py"), []byte(minimalWSGIAppIgnoringSIGTERM), 0644)
 
-	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", 1, "python3")
+	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3")
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup: %v", err)
 	}
@@ -1673,6 +1705,14 @@ func skipIfNoPython(t *testing.T) {
 	}
 }
 
+func skipIfNoGevent(t *testing.T) {
+	t.Helper()
+	skipIfNoPython(t)
+	if err := exec.Command("python3", "-c", "import gevent").Run(); err != nil {
+		t.Skip("gevent not installed, skipping ESGI worker test")
+	}
+}
+
 const minimalWSGIApp = `def app(environ, start_response):
     start_response('200 OK', [('Content-Type', 'text/plain')])
     return [b'Hello from Python']
@@ -1695,7 +1735,7 @@ func TestPythonWorkerGroup_LoadsAndServesWSGI(t *testing.T) {
 		t.Fatalf("failed to write app.py: %v", err)
 	}
 
-	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", 1, "python3")
+	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3")
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
 	}
@@ -1747,7 +1787,7 @@ func TestPythonWorkerGroup_LoadsAndServesASGI(t *testing.T) {
 		t.Fatalf("failed to write app.py: %v", err)
 	}
 
-	wg, err := NewPythonWorkerGroup("asgi", "app:app", tempDir, "", "", 1, "python3")
+	wg, err := NewPythonWorkerGroup("asgi", "app:app", tempDir, "", "", "uvloop", 1, "python3")
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
 	}
@@ -1784,6 +1824,65 @@ func TestPythonWorkerGroup_LoadsAndServesASGI(t *testing.T) {
 	}
 	if !bytes.Contains(body, []byte("Hello from ASGI")) {
 		t.Errorf("expected body to contain 'Hello from ASGI', got: %s", body)
+	}
+}
+
+const minimalESGIApp = `def application(scope, protocol):
+    if scope["proto"] != "http":
+        protocol.response_bytes(500, [("Content-Type", "text/plain")], b"bad")
+        return
+    protocol.response_bytes(200, [("Content-Type", "text/plain")], b"Hello from ESGI")
+`
+
+func TestPythonWorkerGroup_LoadsAndServesESGI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	skipIfNoPython(t)
+
+	tempDir := t.TempDir()
+	appPath := filepath.Join(tempDir, "app.py")
+	if err := os.WriteFile(appPath, []byte(minimalESGIApp), 0644); err != nil {
+		t.Fatalf("failed to write app.py: %v", err)
+	}
+
+	wg, err := NewPythonWorkerGroup("esgi", "app:application", tempDir, "", "", "gevent", 1, "python3")
+	if err != nil {
+		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
+	}
+	defer wg.Cleanup()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = wg.HandleRequest(w, r)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go server.Serve(listener)
+	defer server.Close()
+
+	baseURL := "http://" + listener.Addr().String()
+	resp, err := http.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d; body: %s", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("Hello from ESGI")) {
+		t.Errorf("expected body to contain 'Hello from ESGI', got: %s", body)
 	}
 }
 

--- a/caddysnake_test.py
+++ b/caddysnake_test.py
@@ -936,6 +936,84 @@ class TestBuildWsgiEnviron:
         assert env["REMOTE_ADDR"] == "::1"
 
 
+# ==================== ESGI scope building ====================
+
+
+class TestEsgiHelpers:
+    def test_http_version(self):
+        assert cs._esgi_http_version("HTTP/1.1") == "1.1"
+        assert cs._esgi_http_version("HTTP/1.0") == "1.0"
+        assert cs._esgi_http_version("1.0") == "1.1"  # no slash: fallback in handler
+
+    def test_scheme_from_headers(self):
+        assert cs._esgi_scheme_from_headers({}) == "http"
+        assert cs._esgi_scheme_from_headers({"x-forwarded-proto": "https"}) == "https"
+        assert cs._esgi_scheme_from_headers({"x-forwarded-proto": "HTTP"}) == "http"
+
+    def test_ws_scheme_from_headers(self):
+        assert cs._esgi_ws_scheme_from_headers({}) == "ws"
+        assert cs._esgi_ws_scheme_from_headers({"x-forwarded-proto": "https"}) == "wss"
+
+    def test_headers_mapping_drops_caddy_internal(self):
+        headers_list = [
+            (b"host", b"x"),
+            (b"caddy-snake-remote-addr", b"10.0.0.1"),
+            (b"x-custom", b"a"),
+            (b"x-custom", b"b"),
+        ]
+        raw = {"host": "x", "caddy-snake-remote-addr": "10.0.0.1"}
+        m = cs._esgi_headers_mapping(headers_list, raw)
+        assert "caddy-snake-remote-addr" not in m
+        assert m.get("x-custom") == "a, b"
+
+    def test_build_http_scope(self):
+        raw = {"host": "example.com:9443", "x-forwarded-proto": "http"}
+        headers_list = [(b"host", b"example.com:9443")]
+        scope = cs._build_esgi_http_scope(
+            "post",
+            "/p%61th/to?foo=bar",
+            "HTTP/1.1",
+            headers_list,
+            raw,
+        )
+        assert scope["proto"] == "http"
+        assert scope["esgi_version"] == "0.1"
+        assert scope["http_version"] == "1.1"
+        assert scope["method"] == "POST"
+        assert scope["path"] == "/path/to"
+        assert scope["query_string"] == "foo=bar"
+        assert scope["server"] == "example.com:9443"
+        assert scope["scheme"] == "http"
+        assert scope["authority"] == "example.com:9443"
+
+    def test_build_http_scope_trusted_client(self):
+        raw = {
+            "host": "x",
+            "caddy-snake-remote-addr": "198.51.100.2",
+            "caddy-snake-remote-port": "12345",
+        }
+        scope = cs._build_esgi_http_scope(
+            "GET",
+            "/",
+            "HTTP/1.1",
+            [(b"host", b"x")],
+            raw,
+        )
+        assert scope["client"] == "198.51.100.2:12345"
+
+    def test_build_ws_scope_scheme(self):
+        raw = {"host": "x", "x-forwarded-proto": "https"}
+        scope = cs._build_esgi_ws_scope(
+            "GET",
+            "/ws",
+            "HTTP/1.1",
+            [(b"host", b"x")],
+            raw,
+        )
+        assert scope["proto"] == "ws"
+        assert scope["scheme"] == "wss"
+
+
 # ==================== WSGI Handler (async) ====================
 
 
@@ -1133,12 +1211,13 @@ class TestMain:
                 ],
             ):
                 # main() would block in run_wsgi_server; mock it to return immediately
-                run_wsgi.side_effect = lambda app, sock: None
+                run_wsgi.side_effect = lambda *args, **kwargs: None
                 cs.main()
                 run_wsgi.assert_called_once()
-                args = run_wsgi.call_args[0]
-                assert callable(args[0])
-                assert args[1] == "/tmp/test.sock"
+                call = run_wsgi.call_args
+                assert callable(call[0][0])
+                assert call[0][1] == "/tmp/test.sock"
+                assert call[0][2] == "sync"
 
     def test_main_asgi_calls_run_asgi_server(self):
         """main() with --interface asgi calls run_asgi_server with imported app."""
@@ -1168,6 +1247,30 @@ class TestMain:
                 assert callable(args[0])
                 assert args[1] == "/tmp/test.sock"
                 assert args[2] is False  # lifespan off
+
+    def test_main_esgi_calls_run_esgi_server(self):
+        """main() with --interface esgi calls run_esgi_server with imported app."""
+        with mock.patch.object(cs, "run_esgi_server") as run_esgi:
+            run_esgi.side_effect = lambda *args, **kwargs: None
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "caddysnake.py",
+                    "--socket",
+                    "/tmp/test.sock",
+                    "--app",
+                    "tests.test_apps.minimal:app",
+                    "--interface",
+                    "esgi",
+                ],
+            ):
+                cs.main()
+                run_esgi.assert_called_once()
+                call = run_esgi.call_args[0]
+                assert callable(call[0])
+                assert call[1] == "/tmp/test.sock"
+                assert call[2] == "gevent"
 
     def test_main_invalid_interface(self):
         with mock.patch.object(

--- a/cmd/embed/pybs.py
+++ b/cmd/embed/pybs.py
@@ -5,6 +5,7 @@ import json
 import time
 import urllib.request
 import urllib.error
+import random
 import os
 from pathlib import Path
 
@@ -81,12 +82,31 @@ WINDOWS_VARIANTS = {
 }
 
 
-def urlopen_with_retry(url, max_retries=5, initial_delay=5):
+def _github_headers() -> dict:
+    """Headers for github.com REST API (uses GITHUB_TOKEN in Actions CI)."""
+    h = {"User-Agent": "caddy-snake-pybs (github.com/mliezun/caddy-snake)"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+        h["Accept"] = "application/vnd.github+json"
+    return h
+
+
+def urlopen_with_retry(
+    url,
+    *,
+    headers=None,
+    max_retries=14,
+    initial_delay=8,
+    max_sleep_seconds=240,
+):
     """Open a URL with retry logic for rate limit errors (HTTP 403/429)."""
     delay = initial_delay
-    for attempt in range(max_retries + 1):
+    total_attempts = max_retries + 1
+    for attempt in range(total_attempts):
         try:
-            response = urllib.request.urlopen(url)
+            req = urllib.request.Request(url, headers=dict(headers or {}))
+            response = urllib.request.urlopen(req)
             if response.status != 200:
                 raise urllib.error.HTTPError(
                     url, response.status, "HTTP Error", response.headers, None
@@ -94,18 +114,20 @@ def urlopen_with_retry(url, max_retries=5, initial_delay=5):
             return response
         except urllib.error.HTTPError as e:
             if e.code in (403, 429) and attempt < max_retries:
-                # Check for Retry-After header
+                # Check for Retry-After header (seconds), cap to avoid stalls
                 retry_after = e.headers.get("Retry-After") if e.headers else None
-                wait = (
+                base = (
                     int(retry_after) if retry_after and retry_after.isdigit() else delay
                 )
+                wait = min(max(base, initial_delay), max_sleep_seconds)
+                jitter = random.uniform(0, min(15.0, max(3.0, wait * 0.15)))
                 print(
-                    f"Rate limited (HTTP {e.code}). Retrying in {wait}s "
-                    f"(attempt {attempt + 1}/{max_retries})...",
+                    f"Rate limited (HTTP {e.code}). Retrying in {wait + jitter:.1f}s "
+                    f"(attempt {attempt + 2}/{total_attempts})...",
                     file=sys.stderr,
                 )
-                time.sleep(wait)
-                delay *= 2  # Exponential backoff
+                time.sleep(wait + jitter)
+                delay = min(delay * 2, max_sleep_seconds)
                 continue
             raise
 
@@ -113,7 +135,7 @@ def urlopen_with_retry(url, max_retries=5, initial_delay=5):
 def get_release(tag: str | None):
     url = f"{GITHUB_API}/latest" if tag == "latest" else f"{GITHUB_API}/tags/{tag}"
     try:
-        with urlopen_with_retry(url) as response:
+        with urlopen_with_retry(url, headers=_github_headers()) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         print(f"HTTP Error {e.code}: {e.reason}", file=sys.stderr)
@@ -361,8 +383,16 @@ def select_asset(
 
 def download_asset(url, filename, dest):
     dest_path = Path(dest) / filename
+    dl_headers = None
+    if "github.com" in url:
+        dl_headers = {
+            "User-Agent": "caddy-snake-pybs (github.com/mliezun/caddy-snake)",
+        }
+        token = os.environ.get("GITHUB_TOKEN")
+        if token:
+            dl_headers["Authorization"] = f"Bearer {token}"
     try:
-        with urlopen_with_retry(url) as response:
+        with urlopen_with_retry(url, headers=dl_headers) as response:
             with open(dest_path, "wb") as f:
                 while True:
                     chunk = response.read(8192)

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture
 description: Technical details about how Caddy-Snake works, its worker model, autoreload, and dynamic modules
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Architecture

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Benchmarks

--- a/docs/docs/embed-app.md
+++ b/docs/docs/embed-app.md
@@ -1,7 +1,7 @@
 ---
 title: Apps as Standalone Binaries
 description: Package your Python app with Caddy Snake and Python into a single, self-contained executable
-sidebar_position: 6
+sidebar_position: 8
 ---
 
 # Apps as Standalone Binaries

--- a/docs/docs/esgi.md
+++ b/docs/docs/esgi.md
@@ -1,0 +1,69 @@
+---
+title: ESGI integration
+description: ESGI gateway support with gevent-only workers and the runtime directive
+sidebar_position: 3
+---
+
+# ESGI integration
+
+[ESGI](https://github.com/mliezun/esgi) (**Event-based Server Gateway Interface**) is a Python gateway specification for HTTP and WebSocket: one application invocation per logical connection, a **`scope`** (metadata), and a **`protocol`** object with **blocking** read/write methods — without an ASGI-style `receive` / `send` loop. The normative draft lives in [**PROTOCOL.md**](https://github.com/mliezun/esgi/blob/main/PROTOCOL.md) (version **0.1-draft**).
+
+## Gevent-only worker
+
+**`module_esgi` always runs in a gevent worker.** There is **no asyncio** on the Python side for the connection to Caddy: the subprocess uses **`gevent.server.StreamServer`**, plain blocking sockets (cooperatively scheduled by gevent), and **greenlets** — e.g. one greenlet for the client connection and one to read WebSocket frames into a queue. Your app remains a **synchronous** `def application(scope, protocol): ...` (or `__esgi__`); it is never `async def` and is never driven by `asyncio`.
+
+Install **`gevent`** in the same environment as your app (e.g. `venv` referenced from the Caddyfile).
+
+## Configuration
+
+Use **`module_esgi`** with the usual `module:variable` import path. Exactly one of `module_wsgi`, `module_asgi`, and `module_esgi` may be set.
+
+**`runtime` must be `gevent`** for ESGI (this is also the default when `runtime` is omitted).
+
+```caddyfile
+python {
+    module_esgi "main:application"
+    runtime gevent
+    venv "./venv"
+    workers 4
+}
+```
+
+Optional hooks from the spec: if the loaded app defines **`__esgi_init__`** / **`__esgi_del__`**, the worker calls them once at process startup and once at orderly shutdown.
+
+Dispatch prefers **`__esgi__(self, scope, protocol)`** when present over a plain callable.
+
+## Runtime semantics {#runtime-semantics}
+
+| Directive | Values | Default (when `runtime` is omitted) |
+| --- | --- | --- |
+| `module_wsgi` | `sync`, `gevent` | `sync` |
+| `module_esgi` | **`gevent`** only | `gevent` |
+| `module_asgi` | `native`, `uvloop` | `uvloop` |
+
+- **`native`** (ASGI): standard `asyncio` event loop (WSGI/ASGI worker subprocess).
+- **`uvloop`** (ASGI): prefer **[uvloop](https://github.com/MagicStack/uvloop)** when installed; otherwise warn and fall back to native asyncio. (Legacy configs may say `libuv`; it is normalized to `uvloop`.)
+
+## Protocol coverage
+
+The current worker targets **0.1-draft** behavior used by real apps:
+
+- **HTTP**: `read_body`, `iter_body`, `response_empty` / `response_str` / `response_bytes`, `response_file`, `response_file_range`, `wait_disconnect` (no-op until disconnect tracking lands).
+- **WebSocket**: `accept` → `WsTransport` with `receive` / `send_bytes` / `send_str`; root `close` with RFC 6455 semantics.
+- **`response_stream`** / full streaming refinements are not implemented yet (`NotImplementedError`).
+
+## Integration tests
+
+The repository includes **`tests/simple_esgi`**: a tiny ESGI app with HTTP and WebSocket echo checks (depends on **`gevent`**). Run it like other Docker integration targets:
+
+```bash
+./tests/integration.sh simple_esgi 3.13
+```
+
+## Roadmap
+
+- Narrow **named exceptions** for oversized bodies and disconnects (spec open questions).
+- **`response_stream`** and chunked/streaming parity with the draft.
+- Optional **true gevent-based WSGI** mode (today `runtime gevent` for WSGI is still documented as thread-pool parity).
+
+For ASGI/WSGI usage, see the main [configuration reference](reference).

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -1,7 +1,7 @@
 ---
 title: Examples
 description: Example implementations using different Python web frameworks
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Examples

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,7 +1,7 @@
 ---
 title: Installation & Distribution
 description: All the ways to install Caddy Snake — PyPI, pre-built binaries, Docker, and building from source
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Installation & Distribution

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Configuration Reference
 
-The `python` directive allows you to serve Python WSGI or ASGI applications through Caddy. It supports both a simple form and a block form with various configuration options.
+The `python` directive allows you to serve Python WSGI, ASGI, or ESGI applications through Caddy. It supports both a simple form and a block form with various configuration options.
 
 ---
 
@@ -36,6 +36,8 @@ The block form provides full configuration:
 python {
     module_wsgi <module_name:variable_name>
     module_asgi <module_name:variable_name>
+    module_esgi <module_name:variable_name>
+    runtime <sync|gevent|native|uvloop>
     lifespan on|off
     working_dir <path>
     venv <path>
@@ -58,7 +60,7 @@ python {
 }
 ```
 
-You must specify either `module_wsgi` or `module_asgi`, but not both.
+You must specify exactly one of `module_wsgi`, `module_asgi`, or `module_esgi`.
 
 ### `module_asgi`
 
@@ -67,6 +69,32 @@ Specifies an ASGI application using the `module:variable` pattern. Use this for 
 ```caddyfile
 python {
     module_asgi "main:app"
+}
+```
+
+### `module_esgi`
+
+Specifies an [ESGI](esgi) application using the `module:variable` pattern (a synchronous `application(scope, protocol)` or `__esgi__` callable).
+
+```caddyfile
+python {
+    module_esgi "main:application"
+    runtime gevent
+}
+```
+
+### `runtime`
+
+Selects how the Python worker runs your app at the gateway boundary. See [ESGI integration: runtime semantics](esgi#runtime-semantics) for details.
+
+- With **`module_wsgi`**: `sync` (default) or `gevent`.
+- With **`module_esgi`**: **`gevent` only** (default).
+- With **`module_asgi`**: `native` or `uvloop` (default when omitted: `uvloop`).
+
+```caddyfile
+python {
+    module_asgi "main:app"
+    runtime native
 }
 ```
 
@@ -314,7 +342,7 @@ That test requires **Python 3** on `PATH`.
 
 ## Notes
 
-- You must specify either `module_wsgi` or `module_asgi`, but not both
+- You must specify exactly one of `module_wsgi`, `module_asgi`, or `module_esgi`
 - The `lifespan` directive is only used in ASGI mode
 - When `working_dir` is specified, the path must exist and be a directory
 - When specified, the `venv` path must point to a valid Python virtual environment

--- a/tests/dynamic/main_test.py
+++ b/tests/dynamic/main_test.py
@@ -19,6 +19,31 @@ APPS = {
 }
 
 
+def wait_for_all_apps_healthy(
+    timeout_seconds: float = 90.0, interval: float = 0.5
+) -> None:
+    """Block until every app returns 200 — workers can start after Caddy's storage log line."""
+
+    deadline = time.time() + timeout_seconds
+    last: dict[str, str] = {}
+    while time.time() < deadline:
+        ok = True
+        for name, expected_body in APPS.items():
+            resp = request_app(name)
+            if resp.status_code != 200 or resp.text != expected_body:
+                ok = False
+                body_preview = (resp.text or "")[:120]
+                last[name] = f"status={resp.status_code} body={body_preview!r}"
+                break
+        if ok:
+            return
+        time.sleep(interval)
+
+    raise AssertionError(
+        f"Dynamic apps not healthy after {timeout_seconds}s ({last=!r})"
+    )
+
+
 def request_app(name: str) -> requests.Response:
     """Send a GET request to the given app subdomain via Host header."""
     host = f"{name}.127.0.0.1.nip.io"
@@ -78,6 +103,9 @@ def test_concurrent_requests():
 
 if __name__ == "__main__":
     start = time.time()
+
+    print(">>> Waiting for all dynamic apps...")
+    wait_for_all_apps_healthy()
 
     print(">>> Testing individual apps...")
     test_individual_apps()

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -13,13 +13,13 @@ set -euo pipefail
 #   ./integration_test.sh simple 3.13-nogil
 #
 # Valid tool names:
-#   django, django_channels, flask, fastapi, simple_autoreload, simple_async, socketio, dynamic
+#   django, django_channels, flask, fastapi, simple_autoreload, simple_async, simple_esgi, socketio, dynamic
 #
 # Valid python versions:
 #   3.12, 3.13, 3.13-nogil, 3.14
 # ---------------------------------------------------------------------------
 
-VALID_TOOLS=("django" "django_channels" "flask" "fastapi" "simple_autoreload" "simple_async" "socketio" "dynamic")
+VALID_TOOLS=("django" "django_channels" "flask" "fastapi" "simple_autoreload" "simple_async" "simple_esgi" "socketio" "dynamic")
 VALID_PYVERSIONS=("3.12" "3.13" "3.13-nogil" "3.14")
 
 usage() {
@@ -94,7 +94,7 @@ apt-get install -yyqq software-properties-common curl ca-certificates git
 
 # Install Go
 echo ">>> Installing Go..."
-curl -fsSL "https://go.dev/dl/go1.24.0.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+curl -fsSL "https://go.dev/dl/go1.26.0.linux-amd64.tar.gz" -o /tmp/go.tar.gz
 tar -C /usr/local -xzf /tmp/go.tar.gz
 export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 go version

--- a/tests/simple_esgi/Caddyfile
+++ b/tests/simple_esgi/Caddyfile
@@ -1,0 +1,17 @@
+{
+	http_port 9080
+	https_port 9443
+	log {
+		level info
+	}
+}
+localhost:9080 {
+	route /* {
+		python {
+			module_esgi "main:application"
+			runtime gevent
+			workers 1
+			venv "./venv"
+		}
+	}
+}

--- a/tests/simple_esgi/main.py
+++ b/tests/simple_esgi/main.py
@@ -1,0 +1,40 @@
+"""Minimal ESGI app (spec 0.1-draft) for integration tests."""
+
+
+def application(scope, protocol):
+    if scope["proto"] == "http":
+        if scope["path"] == "/hello" and scope["method"] == "GET":
+            protocol.response_bytes(
+                200,
+                [("Content-Type", "text/plain; charset=utf-8")],
+                b"hello esgi",
+            )
+            return
+        if scope["path"] == "/echo" and scope["method"] == "POST":
+            body = protocol.read_body()
+            protocol.response_bytes(
+                200,
+                [("Content-Type", "application/octet-stream")],
+                body,
+            )
+            return
+        protocol.response_bytes(404, [("Content-Type", "text/plain")], b"not found")
+        return
+
+    if scope["proto"] == "ws":
+        if scope["path"] != "/ws":
+            protocol.close(code=1008, reason="invalid path")
+            return
+        ws = protocol.accept()
+        while True:
+            msg = ws.receive()
+            if msg.kind == 0:
+                break
+            if msg.kind == 2:
+                ws.send_str(f"ECHO:{msg.data}")
+            elif msg.kind == 1:
+                ws.send_bytes(b"ECHO:" + msg.data)
+        protocol.close()
+        return
+
+    protocol.response_bytes(500, [("Content-Type", "text/plain")], b"bad scope")

--- a/tests/simple_esgi/main_test.py
+++ b/tests/simple_esgi/main_test.py
@@ -1,0 +1,43 @@
+import sys
+
+import requests
+import websocket
+
+BASE_URL = "http://localhost:9080"
+WS_URL = "ws://localhost:9080/ws"
+
+
+def test_http_hello():
+    r = requests.get(f"{BASE_URL}/hello", timeout=10)
+    assert r.status_code == 200, r.text
+    assert r.content == b"hello esgi"
+
+
+def test_http_post_echo():
+    payload = b"integration-bytes"
+    r = requests.post(f"{BASE_URL}/echo", data=payload, timeout=10)
+    assert r.status_code == 200
+    assert r.content == payload
+
+
+def test_websocket_echo_text():
+    ws = websocket.WebSocket()
+    try:
+        ws.connect(WS_URL, timeout=10)
+        ws.send("ping-esgi")
+        reply = ws.recv()
+        assert reply == "ECHO:ping-esgi", reply
+    finally:
+        ws.close()
+
+
+def main():
+    test_http_hello()
+    test_http_post_echo()
+    test_websocket_echo_text()
+    print("simple_esgi integration tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/simple_esgi/main_test.py
+++ b/tests/simple_esgi/main_test.py
@@ -1,4 +1,8 @@
+import os
 import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 import websocket
@@ -6,18 +10,40 @@ import websocket
 BASE_URL = "http://localhost:9080"
 WS_URL = "ws://localhost:9080/ws"
 
+# HTTP load (matches other integration apps)
+HTTP_POOL_WORKERS = 4
 
-def test_http_hello():
-    r = requests.get(f"{BASE_URL}/hello", timeout=10)
+# WebSocket load: many concurrent connections, multiple frames each (text + binary),
+# plus one medium-sized binary payload per session for framing pressure.
+WS_POOL_WORKERS = 8
+WS_SMALL_ROUNDS_PER_CONN = 24
+WS_LARGE_BINARY_BYTES = 24 * 1024
+
+
+def assert_http_hello():
+    r = requests.get(f"{BASE_URL}/hello")
     assert r.status_code == 200, r.text
     assert r.content == b"hello esgi"
 
 
-def test_http_post_echo():
+def assert_http_post_echo():
     payload = b"integration-bytes"
-    r = requests.post(f"{BASE_URL}/echo", data=payload, timeout=10)
+    r = requests.post(f"{BASE_URL}/echo", data=payload)
     assert r.status_code == 200
     assert r.content == payload
+
+
+def http_roundtrip():
+    assert_http_hello()
+    assert_http_post_echo()
+
+
+def test_http_hello():
+    assert_http_hello()
+
+
+def test_http_post_echo():
+    assert_http_post_echo()
 
 
 def test_websocket_echo_text():
@@ -31,10 +57,102 @@ def test_websocket_echo_text():
         ws.close()
 
 
+def test_websocket_echo_binary():
+    ws = websocket.WebSocket()
+    try:
+        ws.connect(WS_URL, timeout=10)
+        blob = b"\x00\xff\xfe\x01binary-esgi-\xaa\xbb"
+        ws.send(blob, opcode=websocket.ABNF.OPCODE_BINARY)
+        reply = ws.recv()
+        assert reply == b"ECHO:" + blob, reply
+    finally:
+        ws.close()
+
+
+def ws_session(seq: int) -> None:
+    """One persistent WebSocket: many small text/binary echoes + one large binary."""
+    ws = websocket.WebSocket()
+    ws.connect(WS_URL, timeout=120)
+    try:
+        for i in range(WS_SMALL_ROUNDS_PER_CONN):
+            text = f"esgi-{seq}-{i}-{uuid.uuid4().hex}"
+            ws.send(text)
+            got = ws.recv()
+            assert got == f"ECHO:{text}", (got, text)
+
+            blob = text.encode("utf-8") + os.urandom(24)
+            ws.send(blob, opcode=websocket.ABNF.OPCODE_BINARY)
+            got_b = ws.recv()
+            assert got_b == b"ECHO:" + blob, (got_b, blob[:32])
+
+        large = os.urandom(WS_LARGE_BINARY_BYTES)
+        ws.send(large, opcode=websocket.ABNF.OPCODE_BINARY)
+        got_large = ws.recv()
+        assert got_large == b"ECHO:" + large
+    finally:
+        ws.close()
+
+
+def make_roundtrips(max_workers: int, count: int):
+    start = time.time()
+    failed = False
+
+    def item_done(fut):
+        exc = fut.exception()
+        if exc:
+            nonlocal failed
+            failed = True
+            raise SystemExit(1) from exc
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for _ in range(count):
+            future = executor.submit(http_roundtrip)
+            future.add_done_callback(item_done)
+
+    if failed:
+        print("Tests failed")
+        exit(1)
+
+    print(f"Completed {count} HTTP roundtrips (hello + POST echo)")
+    print(f"Elapsed: {time.time() - start}s")
+
+
+def make_ws_sessions(max_workers: int, count: int):
+    start = time.time()
+    failed = False
+
+    def item_done(fut):
+        exc = fut.exception()
+        if exc:
+            nonlocal failed
+            failed = True
+            raise SystemExit(1) from exc
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for seq in range(count):
+            future = executor.submit(ws_session, seq)
+            future.add_done_callback(item_done)
+
+    if failed:
+        print("Tests failed")
+        exit(1)
+
+    rounds = WS_SMALL_ROUNDS_PER_CONN
+    print(
+        f"Completed {count} WebSocket sessions "
+        f"({rounds} small text/binary rounds + 1×{WS_LARGE_BINARY_BYTES}b binary each)"
+    )
+    print(f"Elapsed: {time.time() - start}s")
+
+
 def main():
-    test_http_hello()
-    test_http_post_echo()
     test_websocket_echo_text()
+    test_websocket_echo_binary()
+
+    count = int(sys.argv[1]) if len(sys.argv) > 1 else 2_500
+    make_roundtrips(max_workers=HTTP_POOL_WORKERS, count=count)
+    make_ws_sessions(max_workers=WS_POOL_WORKERS, count=count)
+
     print("simple_esgi integration tests passed")
     return 0
 

--- a/tests/simple_esgi/requirements.txt
+++ b/tests/simple_esgi/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2024.2.2
+charset-normalizer==3.3.2
+gevent==24.11.1
+idna==3.7
+requests==2.32.2
+urllib3==2.2.2
+websocket-client==1.8.0


### PR DESCRIPTION
## Summary

Adds **[ESGI](https://github.com/mliezun/esgi)** gateway support: `module_esgi` in the Caddyfile, `python-server --server-type esgi`, and a **gevent-only** Python worker (blocking `application(scope, protocol)`; no asyncio on the Go↔Python transport).

## Changes

- **Go:** `module_esgi`, `runtime` validation (ESGI → `gevent` only), dynamic/static handlers, CLI updates.
- **Python:** `run_esgi_server` with gevent `StreamServer`, Unix socket listen path, HTTP + WebSocket per the ESGI draft.
- **Tests:** `tests/simple_esgi` integration target; Go + pytest coverage for ESGI helpers and worker.
- **CI:** `simple_esgi` in Linux integration matrix; skip on `3.13t` nogil (gevent).
- **Docs:** `docs/docs/esgi.md`, README/reference/AGENTS updates; Docker integration script uses Go 1.26.

## Notes

- ASGI `runtime` retains `native` / `uvloop` naming (with `libuv` as legacy alias where applicable in Go).

Made with [Cursor](https://cursor.com)