### PR TITLE
fix: graceful ASGI disconnect during streaming

### DIFF
--- a/caddysnake.py
+++ b/caddysnake.py
@@ -31,13 +31,11 @@ class ClientDisconnected(Exception):
     """Raised when the downstream client closes the connection mid-response."""
 
 
-_CLIENT_DISCONNECT_ERRORS = (
-    ConnectionError,
-    ConnectionResetError,
-    OSError,
-    RuntimeError,
-    BrokenPipeError,
-)
+# Errors raised when writing to a transport whose peer has gone away.
+# OSError covers ConnectionError/ConnectionResetError/BrokenPipeError. RuntimeError
+# is included because uvloop raises it ("unable to perform operation ...; the
+# handler is closed") when the underlying socket has already been torn down.
+_CLIENT_DISCONNECT_ERRORS = (OSError, RuntimeError)
 
 
 def setup_paths(working_dir, venv):
@@ -753,12 +751,10 @@ def _encode_header(name, value):
     return name, value
 
 
-async def _handle_asgi_http(writer, app, scope, body_stream, reader=None):
+async def _handle_asgi_http(writer, app, scope, body_stream):
     """Handle an ASGI HTTP connection."""
     body_done = False
-    body_done_event = asyncio.Event()
     disconnect_event = asyncio.Event()
-    watch_task = None
 
     async def receive():
         nonlocal body_done
@@ -767,7 +763,6 @@ async def _handle_asgi_http(writer, app, scope, body_stream, reader=None):
             if chunk:
                 return {"type": "http.request", "body": chunk, "more_body": True}
             body_done = True
-            body_done_event.set()
             return {"type": "http.request", "body": b"", "more_body": False}
         await disconnect_event.wait()
         return {"type": "http.disconnect"}
@@ -779,49 +774,34 @@ async def _handle_asgi_http(writer, app, scope, body_stream, reader=None):
     has_cl = False
     has_te = False
 
-    def _mark_client_disconnected():
-        disconnect_event.set()
+    def _client_gone():
+        # On native asyncio a failed write does not raise; the transport is
+        # force-closed and is_closing() flips to True. uvloop raises directly
+        # (handled by _CLIENT_DISCONNECT_ERRORS), but is_closing() is a cheap
+        # check that stops a streaming app promptly on either runtime without
+        # consuming bytes from the socket (which would corrupt keep-alive).
+        is_closing = getattr(writer, "is_closing", None)
+        return bool(is_closing()) if callable(is_closing) else False
 
     def _write_to_client(data):
         try:
             writer.write(data)
         except _CLIENT_DISCONNECT_ERRORS:
-            _mark_client_disconnected()
+            disconnect_event.set()
             raise ClientDisconnected
 
     async def _drain_to_client():
         try:
             await writer.drain()
         except _CLIENT_DISCONNECT_ERRORS:
-            _mark_client_disconnected()
+            disconnect_event.set()
             raise ClientDisconnected
-
-    async def _watch_client_disconnect():
-        await body_done_event.wait()
-        if reader is None or disconnect_event.is_set() or response_complete:
-            return
-        try:
-            while not disconnect_event.is_set() and not response_complete:
-                data = await reader.read(4096)
-                if not data:
-                    break
-        except (
-            asyncio.IncompleteReadError,
-            ConnectionError,
-            ConnectionResetError,
-            OSError,
-        ):
-            pass
-        finally:
-            _mark_client_disconnected()
-
-    if reader is not None:
-        watch_task = asyncio.create_task(_watch_client_disconnect())
 
     async def send(message):
         nonlocal response_started, response_complete, use_chunked
         nonlocal pending_headers, has_cl, has_te
-        if disconnect_event.is_set():
+        if disconnect_event.is_set() or _client_gone():
+            disconnect_event.set()
             raise ClientDisconnected
         msg_type = message["type"]
 
@@ -925,12 +905,6 @@ async def _handle_asgi_http(writer, app, scope, body_stream, reader=None):
             await _send_error_response()
     finally:
         disconnect_event.set()
-        if watch_task is not None:
-            watch_task.cancel()
-            try:
-                await watch_task
-            except asyncio.CancelledError:
-                pass
         await body_stream.discard()
 
 
@@ -1911,7 +1885,7 @@ async def _handle_asgi_connection(reader, writer, app, state):
                 await _handle_asgi_websocket(reader, writer, app, scope, raw_headers)
                 break
             else:
-                await _handle_asgi_http(writer, app, scope, body_stream, reader)
+                await _handle_asgi_http(writer, app, scope, body_stream)
 
             connection = raw_headers.get("connection", "")
             if "close" in connection.lower():

--- a/caddysnake.py
+++ b/caddysnake.py
@@ -27,6 +27,19 @@ from http import HTTPStatus
 from urllib.parse import unquote
 
 
+class ClientDisconnected(Exception):
+    """Raised when the downstream client closes the connection mid-response."""
+
+
+_CLIENT_DISCONNECT_ERRORS = (
+    ConnectionError,
+    ConnectionResetError,
+    OSError,
+    RuntimeError,
+    BrokenPipeError,
+)
+
+
 def setup_paths(working_dir, venv):
     """Configure sys.path for working directory and virtualenv."""
     if working_dir:
@@ -740,10 +753,12 @@ def _encode_header(name, value):
     return name, value
 
 
-async def _handle_asgi_http(writer, app, scope, body_stream):
+async def _handle_asgi_http(writer, app, scope, body_stream, reader=None):
     """Handle an ASGI HTTP connection."""
     body_done = False
+    body_done_event = asyncio.Event()
     disconnect_event = asyncio.Event()
+    watch_task = None
 
     async def receive():
         nonlocal body_done
@@ -752,6 +767,7 @@ async def _handle_asgi_http(writer, app, scope, body_stream):
             if chunk:
                 return {"type": "http.request", "body": chunk, "more_body": True}
             body_done = True
+            body_done_event.set()
             return {"type": "http.request", "body": b"", "more_body": False}
         await disconnect_event.wait()
         return {"type": "http.disconnect"}
@@ -763,9 +779,50 @@ async def _handle_asgi_http(writer, app, scope, body_stream):
     has_cl = False
     has_te = False
 
+    def _mark_client_disconnected():
+        disconnect_event.set()
+
+    def _write_to_client(data):
+        try:
+            writer.write(data)
+        except _CLIENT_DISCONNECT_ERRORS:
+            _mark_client_disconnected()
+            raise ClientDisconnected
+
+    async def _drain_to_client():
+        try:
+            await writer.drain()
+        except _CLIENT_DISCONNECT_ERRORS:
+            _mark_client_disconnected()
+            raise ClientDisconnected
+
+    async def _watch_client_disconnect():
+        await body_done_event.wait()
+        if reader is None or disconnect_event.is_set() or response_complete:
+            return
+        try:
+            while not disconnect_event.is_set() and not response_complete:
+                data = await reader.read(4096)
+                if not data:
+                    break
+        except (
+            asyncio.IncompleteReadError,
+            ConnectionError,
+            ConnectionResetError,
+            OSError,
+        ):
+            pass
+        finally:
+            _mark_client_disconnected()
+
+    if reader is not None:
+        watch_task = asyncio.create_task(_watch_client_disconnect())
+
     async def send(message):
         nonlocal response_started, response_complete, use_chunked
         nonlocal pending_headers, has_cl, has_te
+        if disconnect_event.is_set():
+            raise ClientDisconnected
         msg_type = message["type"]
 
         if msg_type == "http.response.start":
@@ -815,47 +872,65 @@ async def _handle_asgi_http(writer, app, scope, body_stream):
                 else:
                     if body_data:
                         buf.extend(body_data)
-                writer.write(buf)
+                _write_to_client(buf)
             else:
                 if use_chunked:
                     if body_data:
-                        writer.write(
+                        _write_to_client(
                             f"{len(body_data):x}\r\n".encode("ascii")
                             + body_data
                             + b"\r\n"
                         )
                     if not more_body:
-                        writer.write(b"0\r\n\r\n")
+                        _write_to_client(b"0\r\n\r\n")
                 else:
                     if body_data:
-                        writer.write(body_data)
+                        _write_to_client(body_data)
 
             if not more_body:
-                await writer.drain()
+                await _drain_to_client()
                 response_complete = True
                 disconnect_event.set()
 
+    async def _send_error_response():
+        nonlocal pending_headers
+        if disconnect_event.is_set():
+            return
+        try:
+            if not response_started:
+                _write_to_client(
+                    b"HTTP/1.1 500 Internal Server Error\r\n"
+                    b"Content-Length: 21\r\n\r\n"
+                    b"Internal Server Error"
+                )
+                await _drain_to_client()
+            else:
+                if pending_headers is not None:
+                    pending_headers.extend(b"\r\n")
+                    _write_to_client(pending_headers)
+                    pending_headers = None
+                if use_chunked and not response_complete:
+                    _write_to_client(b"0\r\n\r\n")
+                await _drain_to_client()
+        except ClientDisconnected:
+            pass
+
     try:
         await app(scope, receive, send)
+    except ClientDisconnected:
+        pass
     except Exception:
-        traceback.print_exc(file=sys.stderr)
-        if not response_started:
-            writer.write(
-                b"HTTP/1.1 500 Internal Server Error\r\n"
-                b"Content-Length: 21\r\n\r\n"
-                b"Internal Server Error"
-            )
-            await writer.drain()
-        else:
-            if pending_headers is not None:
-                pending_headers.extend(b"\r\n")
-                writer.write(pending_headers)
-                pending_headers = None
-            if use_chunked and not response_complete:
-                writer.write(b"0\r\n\r\n")
-            await writer.drain()
+        if not disconnect_event.is_set():
+            traceback.print_exc(file=sys.stderr)
+            await _send_error_response()
     finally:
         disconnect_event.set()
+        if watch_task is not None:
+            watch_task.cancel()
+            try:
+                await watch_task
+            except asyncio.CancelledError:
+                pass
         await body_stream.discard()
 
 
@@ -1836,7 +1911,7 @@ async def _handle_asgi_connection(reader, writer, app, state):
                 await _handle_asgi_websocket(reader, writer, app, scope, raw_headers)
                 break
             else:
-                await _handle_asgi_http(writer, app, scope, body_stream)
+                await _handle_asgi_http(writer, app, scope, body_stream, reader)
 
             connection = raw_headers.get("connection", "")
             if "close" in connection.lower():

--- a/caddysnake_test.py
+++ b/caddysnake_test.py
@@ -617,6 +617,52 @@ class TestHandleAsgiHttp:
         combined = b"".join(evt.get("body", b"") for evt in received)
         assert combined == b"abcdefghij"
 
+    async def test_client_disconnect_during_streaming_response(self):
+        write_calls = 0
+
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"chunk1",
+                    "more_body": True,
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"chunk2",
+                    "more_body": True,
+                }
+            )
+
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+
+        written = []
+
+        def _write(data):
+            nonlocal write_calls
+            write_calls += 1
+            if write_calls > 1:
+                raise BrokenPipeError
+            written.append(data)
+
+        async def _drain():
+            pass
+
+        writer = mock.Mock()
+        writer.write = _write
+        writer.drain = _drain
+
+        scope = {"type": "http"}
+        body_stream = cs._HttpBodyStream(reader, content_length=0)
+        await cs._handle_asgi_http(writer, app, scope, body_stream, reader)
+
+        assert write_calls == 2
+        assert len(written) == 1
+
 
 # ==================== ASGI _handle_asgi_websocket ====================
 

--- a/caddysnake_test.py
+++ b/caddysnake_test.py
@@ -489,6 +489,7 @@ class TestHandleAsgiHttp:
         written = []
         writer = mock.Mock()
         writer.write = lambda d: written.append(d)
+        writer.is_closing = lambda: False
 
         async def mock_drain():
             pass
@@ -541,6 +542,7 @@ class TestHandleAsgiHttp:
         writer = mock.Mock()
         writer.write = lambda d: written.append(d)
         writer.drain = _drain
+        writer.is_closing = lambda: False
 
         scope = {"type": "http"}
         body_stream = cs._HttpBodyStream(asyncio.StreamReader(), content_length=0)
@@ -563,6 +565,7 @@ class TestHandleAsgiHttp:
         writer = mock.Mock()
         writer.write = lambda d: written.append(d)
         writer.drain = _drain
+        writer.is_closing = lambda: False
 
         scope = {"type": "http"}
         body_stream = cs._HttpBodyStream(asyncio.StreamReader(), content_length=0)
@@ -591,6 +594,7 @@ class TestHandleAsgiHttp:
         writer = mock.Mock()
         writer.write = lambda d: None
         writer.drain = _drain
+        writer.is_closing = lambda: False
 
         req = (
             b"POST /upload HTTP/1.1\r\n"
@@ -617,25 +621,66 @@ class TestHandleAsgiHttp:
         combined = b"".join(evt.get("body", b"") for evt in received)
         assert combined == b"abcdefghij"
 
-    async def test_client_disconnect_during_streaming_response(self):
+    async def test_client_disconnect_during_streaming_response_native(self):
+        """Native asyncio: writes fail silently, is_closing() flips to True.
+
+        The next send() must raise ClientDisconnected so the app stops, and no
+        traceback should escape _handle_asgi_http.
+        """
+        sent_chunks = []
+        closing = {"value": False}
+
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            for i in range(5):
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": f"chunk{i}".encode(),
+                        "more_body": True,
+                    }
+                )
+                sent_chunks.append(i)
+                # Simulate the transport being force-closed after the first body
+                # write (peer went away); native asyncio does not raise on write.
+                closing["value"] = True
+
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+
+        written = []
+
+        async def _drain():
+            pass
+
+        writer = mock.Mock()
+        writer.write = lambda d: written.append(d)
+        writer.drain = _drain
+        writer.is_closing = lambda: closing["value"]
+
+        scope = {"type": "http"}
+        body_stream = cs._HttpBodyStream(reader, content_length=0)
+        await cs._handle_asgi_http(writer, app, scope, body_stream)
+
+        # First chunk goes out; the second send() observes is_closing() and aborts.
+        assert sent_chunks == [0]
+
+    async def test_client_disconnect_during_streaming_response_uvloop(self):
+        """uvloop: writer.write() raises synchronously on a closed transport."""
+        sent_chunks = []
         write_calls = 0
 
         async def app(scope, receive, send):
             await send({"type": "http.response.start", "status": 200, "headers": []})
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b"chunk1",
-                    "more_body": True,
-                }
-            )
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b"chunk2",
-                    "more_body": True,
-                }
-            )
+            for i in range(5):
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": f"chunk{i}".encode(),
+                        "more_body": True,
+                    }
+                )
+                sent_chunks.append(i)
 
         reader = asyncio.StreamReader()
         reader.feed_eof()
@@ -646,7 +691,11 @@ class TestHandleAsgiHttp:
             nonlocal write_calls
             write_calls += 1
             if write_calls > 1:
-                raise BrokenPipeError
+                # uvloop raises this exact error when the handler is closed.
+                raise RuntimeError(
+                    "unable to perform operation on <UnixTransport ...>; "
+                    "the handler is closed"
+                )
             written.append(data)
 
         async def _drain():
@@ -655,13 +704,15 @@ class TestHandleAsgiHttp:
         writer = mock.Mock()
         writer.write = _write
         writer.drain = _drain
+        writer.is_closing = lambda: False
 
         scope = {"type": "http"}
         body_stream = cs._HttpBodyStream(reader, content_length=0)
-        await cs._handle_asgi_http(writer, app, scope, body_stream, reader)
+        await cs._handle_asgi_http(writer, app, scope, body_stream)
 
+        # Write #1 (headers + first chunk) succeeds; write #2 (next chunk) raises.
+        assert sent_chunks == [0]
         assert write_calls == 2
-        assert len(written) == 1
 
 
 # ==================== ASGI _handle_asgi_websocket ====================
@@ -747,6 +798,7 @@ class TestHandleAsgiConnection:
         writer.drain = _drain
         writer.close = lambda: None
         writer.wait_closed = _wait_closed
+        writer.is_closing = lambda: False
 
         async def app(scope, receive, send):
             assert scope["type"] == "http"

--- a/tests/fastapi/Caddyfile
+++ b/tests/fastapi/Caddyfile
@@ -33,6 +33,15 @@ localhost:9080 {
 		}
 	}
 
+	route /stream/* {
+		python {
+			module_asgi "main:app"
+			lifespan on
+			workers 1
+			venv "./venv"
+		}
+	}
+
 	route / {
 		respond 404
 	}

--- a/tests/fastapi/main.py
+++ b/tests/fastapi/main.py
@@ -1,6 +1,7 @@
+import asyncio
 import os
 import sys
-from typing import Optional
+from typing import AsyncGenerator, Optional
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, UploadFile
@@ -55,6 +56,17 @@ def chunked_blob(blob: str):
 @app.get("/stream-item/{id}")
 async def item_stream(id: str) -> StreamingResponse:
     return StreamingResponse(chunked_blob(db[id].blob), media_type="text/event-stream")
+
+
+async def slow_stream() -> AsyncGenerator[bytes, None]:
+    for i in range(100):
+        yield f"chunk-{i}\n".encode()
+        await asyncio.sleep(0.05)
+
+
+@app.get("/stream/slow")
+async def stream_slow() -> StreamingResponse:
+    return StreamingResponse(slow_stream(), media_type="text/plain")
 
 
 @app.post("/item/upload-file/")

--- a/tests/fastapi/main_test.py
+++ b/tests/fastapi/main_test.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import socket
 import uuid
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -115,6 +116,53 @@ def find_and_terminate_process(process_name):
             pass
 
 
+def test_stream_client_disconnect(log_path: str = "caddy.log"):
+    """Client disconnect mid-stream must not leave worker tracebacks."""
+    with open(log_path, "rb") as fd:
+        fd.seek(0, os.SEEK_END)
+        log_offset = fd.tell()
+
+    sock = socket.create_connection(("localhost", 9080))
+    try:
+        sock.sendall(
+            b"GET /stream/slow HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        data = b""
+        while b"chunk-" not in data:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        assert b"chunk-" in data, (
+            "expected at least one streamed chunk before disconnect"
+        )
+    finally:
+        sock.close()
+
+    time.sleep(1.5)
+
+    with open(log_path, "r", encoding="utf-8", errors="replace") as fd:
+        fd.seek(log_offset)
+        logs = fd.read()
+
+    disconnect_markers = (
+        "RuntimeError: unable to perform operation",
+        "Unhandled exception in client_connected_cb",
+        "BrokenPipeError",
+        "ConnectionResetError",
+        "socket.send() raised exception.",
+    )
+    for marker in disconnect_markers:
+        assert marker not in logs, f"worker logged {marker!r} after client disconnect"
+
+    assert "_handle_asgi_http" not in logs, (
+        "worker printed an ASGI handler traceback after client disconnect"
+    )
+
+    response = requests.get(f"{BASE_URL}/item/missing", timeout=5)
+    assert response.status_code == 200
+
+
 def check_lifespan_events_on_logs(logs: str):
     startup_count = 0
     with open(logs, "r") as fd:
@@ -130,6 +178,7 @@ if __name__ == "__main__":
     import sys
 
     count = int(sys.argv[1]) if len(sys.argv) > 1 else 2_500
+    test_stream_client_disconnect()
     make_objects(max_workers=4, count=count)
     find_and_terminate_process("caddy")
     time.sleep(5)

--- a/tests/fastapi/main_test.py
+++ b/tests/fastapi/main_test.py
@@ -116,8 +116,33 @@ def find_and_terminate_process(process_name):
             pass
 
 
+def wait_for_stream_endpoint(timeout: float = 60.0) -> None:
+    """Wait until the /stream/slow route's Python worker is accepting connections."""
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("localhost", 9080), timeout=2) as sock:
+                sock.sendall(
+                    b"GET /stream/slow HTTP/1.1\r\n"
+                    b"Host: localhost\r\n"
+                    b"Connection: close\r\n\r\n"
+                )
+                data = sock.recv(4096)
+            if b"HTTP/1.1 200" in data and b"chunk-" in data:
+                return
+            if data:
+                last_error = data.split(b"\r\n", 1)[0]
+        except OSError as exc:
+            last_error = exc
+        time.sleep(0.25)
+    raise TimeoutError(f"/stream/slow not ready after {timeout}s: {last_error!r}")
+
+
 def test_stream_client_disconnect(log_path: str = "caddy.log"):
     """Client disconnect mid-stream must not leave worker tracebacks."""
+    wait_for_stream_endpoint()
+
     with open(log_path, "rb") as fd:
         fd.seek(0, os.SEEK_END)
         log_offset = fd.tell()
@@ -134,7 +159,7 @@ def test_stream_client_disconnect(log_path: str = "caddy.log"):
                 break
             data += chunk
         assert b"chunk-" in data, (
-            "expected at least one streamed chunk before disconnect"
+            f"expected at least one streamed chunk before disconnect, got: {data[:200]!r}"
         )
     finally:
         sock.close()


### PR DESCRIPTION
Handle client disconnect during streaming ASGI responses without worker tracebacks. Includes a repro integration test.

Fixes #172

Made with [Cursor](https://cursor.com)