### PR TITLE
Support path-prefixed python route blocks in Caddyfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,9 @@ def application(scope, protocol):
 
 ```caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_esgi "main:application"
-            runtime gevent
-        }
+    python /* {
+        module_esgi "main:application"
+        runtime gevent
     }
 }
 ```
@@ -182,10 +180,8 @@ def hello():
 
 ```Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_wsgi "main:app"
-        }
+    python /* {
+        module_wsgi "main:app"
     }
 }
 ```
@@ -218,11 +214,9 @@ def hello():
 
 ```Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_asgi "main:app"
-            lifespan on
-        }
+    python /* {
+        module_asgi "main:app"
+        lifespan on
     }
 }
 ```
@@ -358,11 +352,9 @@ This is useful for multi-tenant setups where each subdomain or route serves a di
 
 ```Caddyfile
 *.example.com:9080 {
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.2}:app"
-            working_dir "{http.request.host.labels.2}/"
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.2}:app"
+        working_dir "{http.request.host.labels.2}/"
     }
 }
 ```
@@ -396,11 +388,9 @@ https://*.project.example {
         on_demand
     }
 
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.2}:app"
-            working_dir "/srv/apps/{http.request.host.labels.2}/"
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.2}:app"
+        working_dir "/srv/apps/{http.request.host.labels.2}/"
     }
 }
 ```

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -807,6 +807,7 @@ func (wg *PythonWorkerGroup) HandleRequest(rw http.ResponseWriter, req *http.Req
 func init() {
 	caddy.RegisterModule(CaddySnake{})
 	httpcaddyfile.RegisterHandlerDirective("python", parsePythonDirective)
+	httpcaddyfile.RegisterDirectiveOrder("python", httpcaddyfile.Before, "respond")
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name: "python-server",
 		Usage: "--server-type wsgi|asgi|esgi --app <module> " +

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1705,6 +1706,88 @@ func TestParsePythonDirective_InvalidCaddyfile(t *testing.T) {
 	_, err := parsePythonDirective(h)
 	if err == nil {
 		t.Fatal("expected error for invalid caddyfile (missing module_wsgi arg)")
+	}
+}
+
+func TestPythonDirectiveCaddyfileAdaptation(t *testing.T) {
+	adapter := caddyfile.Adapter{
+		ServerType: httpcaddyfile.ServerType{},
+	}
+
+	for _, tc := range []struct {
+		name        string
+		input       string
+		expectError bool
+		contains    []string
+	}{
+		{
+			name: "path prefixed site level",
+			input: `:9080 {
+				python /api/* {
+					module_asgi "main:app"
+				}
+			}`,
+			contains: []string{`"handler":"python"`, `"/api/*"`, `"module_asgi":"main:app"`},
+		},
+		{
+			name: "site level block without matcher",
+			input: `:9080 {
+				python {
+					module_wsgi "main:app"
+				}
+			}`,
+			contains: []string{`"handler":"python"`, `"module_wsgi":"main:app"`},
+		},
+		{
+			name: "shorthand wsgi module",
+			input: `:9080 {
+				python main:app
+			}`,
+			contains: []string{`"handler":"python"`, `"module_wsgi":"main:app"`},
+		},
+		{
+			name: "route block backwards compat",
+			input: `:9080 {
+				route /api {
+					python {
+						module_asgi "main:app"
+					}
+				}
+			}`,
+			contains: []string{`"handler":"python"`, `"/api"`, `"module_asgi":"main:app"`},
+		},
+		{
+			name: "path prefixed with fallback respond",
+			input: `:9080 {
+				python /item/* {
+					module_wsgi "main:app"
+				}
+				respond 404
+			}`,
+			contains: []string{`"handler":"python"`, `"/item/*"`, `"handler":"static_response"`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := adapter.Adapt([]byte(tc.input), nil)
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected adaptation error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected adaptation error: %v", err)
+			}
+			outStr := string(out)
+			for _, want := range tc.contains {
+				if !strings.Contains(outStr, want) {
+					t.Errorf("adapted JSON missing %q\n%s", want, outStr)
+				}
+			}
+			if !json.Valid(out) {
+				t.Fatalf("adapted output is not valid JSON: %s", outStr)
+			}
+		})
 	}
 }
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -43,13 +43,11 @@ def create_item(item: Item):
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_asgi "main:app"
-            lifespan on
-            workers 1
-            venv "./venv"
-        }
+    python /* {
+        module_asgi "main:app"
+        lifespan on
+        workers 1
+        venv "./venv"
     }
 }
 ```
@@ -102,12 +100,10 @@ def create_item():
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_wsgi "main:app"
-            workers 4
-            venv "./venv"
-        }
+    python /* {
+        module_wsgi "main:app"
+        workers 4
+        venv "./venv"
     }
 }
 ```
@@ -170,12 +166,10 @@ def item_list(request):
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_wsgi "mysite.wsgi:application"
-            workers 1
-            venv "./venv"
-        }
+    python /* {
+        module_wsgi "mysite.wsgi:application"
+        workers 1
+        venv "./venv"
     }
 }
 ```
@@ -215,12 +209,10 @@ application = get_asgi_application()
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_asgi "mysite.asgi:application"
-            workers 1
-            venv "./venv"
-        }
+    python /* {
+        module_asgi "mysite.asgi:application"
+        workers 1
+        venv "./venv"
     }
 }
 ```
@@ -268,13 +260,11 @@ app.mount('/', socket_app)
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_asgi "main:app"
-            lifespan on
-            workers 1
-            venv "./venv"
-        }
+    python /* {
+        module_asgi "main:app"
+        lifespan on
+        workers 1
+        venv "./venv"
     }
 }
 ```
@@ -321,12 +311,10 @@ def hello():
 ```caddyfile
 # Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_wsgi "main:app"
-            venv "./venv"
-            autoreload
-        }
+    python /* {
+        module_wsgi "main:app"
+        venv "./venv"
+        autoreload
     }
 }
 ```
@@ -393,12 +381,10 @@ def index():
 ```caddyfile
 # Caddyfile
 *.127.0.0.1.nip.io:9080 {
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.6}:app"
-            working_dir "{http.request.host.labels.6}/"
-            workers 1
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.6}:app"
+        working_dir "{http.request.host.labels.6}/"
+        workers 1
     }
 }
 ```
@@ -428,13 +414,11 @@ Add `autoreload` to automatically reload individual apps when their Python files
 
 ```caddyfile
 *.127.0.0.1.nip.io:9080 {
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.6}:app"
-            working_dir "{http.request.host.labels.6}/"
-            workers 1
-            autoreload
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.6}:app"
+        working_dir "{http.request.host.labels.6}/"
+        workers 1
+        autoreload
     }
 }
 ```

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -120,11 +120,9 @@ def hello():
 
 ```Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_asgi "main:app"
-            lifespan on
-        }
+    python /* {
+        module_asgi "main:app"
+        lifespan on
     }
 }
 ```
@@ -163,10 +161,8 @@ def hello():
 
 ```Caddyfile
 http://localhost:9080 {
-    route {
-        python {
-            module_wsgi "main:app"
-        }
+    python /* {
+        module_wsgi "main:app"
     }
 }
 ```

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -6,7 +6,31 @@ sidebar_position: 2
 
 # Configuration Reference
 
-The `python` directive allows you to serve Python WSGI, ASGI, or ESGI applications through Caddy. It supports both a simple form and a block form with various configuration options.
+The `python` directive allows you to serve Python WSGI, ASGI, or ESGI applications through Caddy. It supports a simple form, a block form, and path-prefixed route blocks.
+
+---
+
+## Route Form (recommended)
+
+Mount a Python app on a URL path directly, without wrapping it in a `route` block:
+
+```caddyfile
+python "/api" {
+    module_asgi "main:app"
+}
+```
+
+The optional matcher can be a path (`/api`, `/api/*`), a named matcher (`@api`), or a catch-all (`*`). Requests are forwarded to Python with the **full request path** unchanged.
+
+For a catch-all site:
+
+```caddyfile
+python /* {
+    module_asgi "main:app"
+}
+```
+
+The older `route { python { ... } }` form remains supported but is no longer recommended.
 
 ---
 
@@ -191,11 +215,9 @@ This is useful for multi-tenant setups where each subdomain or route serves a di
 
 ```caddyfile
 *.example.com:9080 {
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.2}:app"
-            working_dir "{http.request.host.labels.2}/"
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.2}:app"
+        working_dir "{http.request.host.labels.2}/"
     }
 }
 ```
@@ -221,12 +243,10 @@ Dynamic module loading works with `autoreload`. When enabled, each resolved work
 
 ```caddyfile
 *.example.com:9080 {
-    route /* {
-        python {
-            module_asgi "{http.request.host.labels.2}:app"
-            working_dir "{http.request.host.labels.2}/"
-            autoreload
-        }
+    python /* {
+        module_asgi "{http.request.host.labels.2}:app"
+        working_dir "{http.request.host.labels.2}/"
+        autoreload
     }
 }
 ```
@@ -257,11 +277,9 @@ https://*.project.example {
 	tls {
 		on_demand
 	}
-	route /* {
-		python {
-			module_asgi "{http.request.host.labels.2}:app"
-			working_dir "/srv/branches/{http.request.host.labels.2}/"
-		}
+	python /* {
+		module_asgi "{http.request.host.labels.2}:app"
+		working_dir "/srv/branches/{http.request.host.labels.2}/"
 	}
 }
 ```
@@ -298,12 +316,10 @@ https://*.203.0.113.43.nip.io {
 		on_demand
 	}
 
-	route /* {
-		python {
-			module_wsgi "app:application"
-			working_dir "/srv/apps/{http.request.host.labels.6}/"
-			workers 2
-		}
+	python /* {
+		module_wsgi "app:application"
+		working_dir "/srv/apps/{http.request.host.labels.6}/"
+		workers 2
 	}
 }
 ```

--- a/tests/django/Caddyfile
+++ b/tests/django/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route /item/* {
-		python {
-			module_wsgi "mysite.wsgi:application"
-			workers 1
-			venv "./venv"
-		}
+	python /item/* {
+		module_wsgi "mysite.wsgi:application"
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/django_channels/Caddyfile
+++ b/tests/django_channels/Caddyfile
@@ -6,20 +6,16 @@
 	}
 }
 localhost:9080 {
-	route /ws/* {
-		python {
-			module_asgi "mysite.asgi:application"
-			workers 1
-			venv "./venv"
-		}
+	python /ws/* {
+		module_asgi "mysite.asgi:application"
+		workers 1
+		venv "./venv"
 	}
 
-	route /item/* {
-		python {
-			module_asgi "mysite.asgi:application"
-			workers 1
-			venv "./venv"
-		}
+	python /item/* {
+		module_asgi "mysite.asgi:application"
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/dynamic/Caddyfile
+++ b/tests/dynamic/Caddyfile
@@ -6,11 +6,9 @@
 	}
 }
 *.127.0.0.1.nip.io:9080 {
-	route /* {
-		python {
-			module_asgi "{http.request.host.labels.6}:app"
-			working_dir "{http.request.host.labels.6}/"
-			workers 1
-		}
+	python /* {
+		module_asgi "{http.request.host.labels.6}:app"
+		working_dir "{http.request.host.labels.6}/"
+		workers 1
 	}
 }

--- a/tests/fastapi/Caddyfile
+++ b/tests/fastapi/Caddyfile
@@ -6,40 +6,32 @@
 	}
 }
 localhost:9080 {
-	route /item/* {
-		python {
-			module_asgi "main:app"
-			lifespan on
-			workers 1
-			venv "./venv"
-		}
+	python /item/* {
+		module_asgi "main:app"
+		lifespan on
+		workers 1
+		venv "./venv"
 	}
 
-	route /other/ {
-		python {
-			module_asgi "main:app"
-			lifespan on
-			workers 1
-			venv "./venv"
-		}
+	python /other/ {
+		module_asgi "main:app"
+		lifespan on
+		workers 1
+		venv "./venv"
 	}
 
-	route /stream-item/* {
-		python {
-			module_asgi "main:app"
-			lifespan on
-			workers 1
-			venv "./venv"
-		}
+	python /stream-item/* {
+		module_asgi "main:app"
+		lifespan on
+		workers 1
+		venv "./venv"
 	}
 
-	route /stream/* {
-		python {
-			module_asgi "main:app"
-			lifespan on
-			workers 1
-			venv "./venv"
-		}
+	python /stream/* {
+		module_asgi "main:app"
+		lifespan on
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/flask/Caddyfile
+++ b/tests/flask/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route /item/* {
-		python {
-			module_wsgi "main:app"
-			workers 1
-			venv "./venv"
-		}
+	python /item/* {
+		module_wsgi "main:app"
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/simple_async/Caddyfile
+++ b/tests/simple_async/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route /item/* {
-		python {
-			module_asgi "main:app"
-			workers 1
-			venv "./venv"
-		}
+	python /item/* {
+		module_asgi "main:app"
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/simple_autoreload/Caddyfile
+++ b/tests/simple_autoreload/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route {
-		python {
-			module_wsgi "main:app"
-			workers 1
-			venv "./venv"
-			autoreload
-		}
+	python {
+		module_wsgi "main:app"
+		workers 1
+		venv "./venv"
+		autoreload
 	}
 }

--- a/tests/simple_cache/Caddyfile
+++ b/tests/simple_cache/Caddyfile
@@ -6,29 +6,23 @@
 	}
 }
 localhost:9080 {
-	route /share/* {
-		python {
-			module_wsgi "main:wsgi_app"
-			workers 2
-			venv "./venv"
-		}
+	python /share/* {
+		module_wsgi "main:wsgi_app"
+		workers 2
+		venv "./venv"
 	}
 
-	route /asgi/* {
-		python {
-			module_asgi "main:asgi_app"
-			workers 1
-			venv "./venv"
-		}
+	python /asgi/* {
+		module_asgi "main:asgi_app"
+		workers 1
+		venv "./venv"
 	}
 
-	route /esgi/* {
-		python {
-			module_esgi "main:application"
-			runtime gevent
-			workers 1
-			venv "./venv"
-		}
+	python /esgi/* {
+		module_esgi "main:application"
+		runtime gevent
+		workers 1
+		venv "./venv"
 	}
 
 	route / {

--- a/tests/simple_esgi/Caddyfile
+++ b/tests/simple_esgi/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route /* {
-		python {
-			module_esgi "main:application"
-			runtime gevent
-			workers 1
-			venv "./venv"
-		}
+	python /* {
+		module_esgi "main:application"
+		runtime gevent
+		workers 1
+		venv "./venv"
 	}
 }

--- a/tests/socketio/Caddyfile
+++ b/tests/socketio/Caddyfile
@@ -6,12 +6,10 @@
 	}
 }
 localhost:9080 {
-	route /socket.io/* {
-		python {
-			module_asgi "main:app"
-			workers 1
-			venv "./venv"
-		}
+	python /socket.io/* {
+		module_asgi "main:app"
+		workers 1
+		venv "./venv"
 	}
 
 	route / {


### PR DESCRIPTION
## Summary
- Register `python` in Caddy directive order so `python "/path" { ... }` works at site level
- Migrate integration test Caddyfiles and docs to the new recommended syntax
- Preserve backwards compatibility with `route { python { ... } }` and `python main:app` shorthand

## Test plan
- [x] `go test -race -v .`
- [x] `go test -race -tags=caddytest -timeout 180s .`
- [x] `pytest caddysnake_test.py -v`
- [ ] `./tests/integration.sh flask 3.13` (Docker unavailable locally; CI)
- [ ] `./tests/integration.sh fastapi 3.13` (Docker unavailable locally; CI)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)