### PR TITLE
Add macOS CI for binary releases and PyPI wheels

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -15,24 +15,56 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-linux:
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04
             artifact: caddy-linux-amd64
-            run_on_pr: true
           - os: ubuntu-22.04-arm
             artifact: caddy-linux-arm64
-            run_on_pr: true
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Build the server
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
+      - name: Rename binary
+        run: mv caddy ${{ matrix.artifact }} # zizmor: ignore[template-injection]
+      - name: Upload caddy binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+      - name: Package caddy binary
+        if: github.event_name == 'release'
+        run: | # zizmor: ignore[template-injection]
+          tar -czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
+      - name: Upload to release
+        if: github.event_name == 'release'
+        run: | # zizmor: ignore[template-injection]
+          gh release upload ${{ github.event.release.tag_name }} ${{ matrix.artifact }}.tar.gz --repo ${{ github.repository }} --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - os: macos-15
             artifact: caddy-darwin-arm64
-            run_on_pr: false
           - os: macos-15-intel
             artifact: caddy-darwin-amd64
-            run_on_pr: false
-    if: matrix.run_on_pr || github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,4 +1,4 @@
-name: Caddy Binary Linux
+name: Caddy Binary
 
 on:
   pull_request:
@@ -19,7 +19,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        include:
+          - os: ubuntu-22.04
+            artifact: caddy-linux-amd64
+            run_on_pr: true
+          - os: ubuntu-22.04-arm
+            artifact: caddy-linux-arm64
+            run_on_pr: true
+          - os: macos-15
+            artifact: caddy-darwin-arm64
+            run_on_pr: false
+          - os: macos-15-intel
+            artifact: caddy-darwin-amd64
+            run_on_pr: false
+    if: matrix.run_on_pr || github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -33,29 +46,20 @@ jobs:
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: Build the server
         run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
-      - name: Choose architecture
-        id: choose-arch
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-22.04-arm" ]; then
-            ARCH=arm64
-          else
-            ARCH=amd64
-          fi
-          echo "ARCH=${ARCH}" >> $GITHUB_OUTPUT
       - name: Rename binary
-        run: mv caddy caddy-linux-${{ steps.choose-arch.outputs.ARCH }} # zizmor: ignore[template-injection]
+        run: mv caddy ${{ matrix.artifact }} # zizmor: ignore[template-injection]
       - name: Upload caddy binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
-          path: caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
       - name: Package caddy binary
         if: github.event_name == 'release'
         run: | # zizmor: ignore[template-injection]
-          tar -czf caddy-linux-${{ steps.choose-arch.outputs.ARCH }}.tar.gz caddy-linux-${{ steps.choose-arch.outputs.ARCH }}
+          tar -czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
       - name: Upload to release
         if: github.event_name == 'release'
         run: | # zizmor: ignore[template-injection]
-          gh release upload ${{ github.event.release.tag_name }} caddy-linux-${{ steps.choose-arch.outputs.ARCH }}.tar.gz --repo ${{ github.repository }} --clobber
+          gh release upload ${{ github.event.release.tag_name }} ${{ matrix.artifact }}.tar.gz --repo ${{ github.repository }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 jobs:
-  build-linux:
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -24,43 +24,6 @@ jobs:
             artifact: caddy-linux-amd64
           - os: ubuntu-22.04-arm
             artifact: caddy-linux-arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.26"
-          cache: false
-      - name: Install Xcaddy
-        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-      - name: Build the server
-        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
-      - name: Rename binary
-        run: mv caddy ${{ matrix.artifact }} # zizmor: ignore[template-injection]
-      - name: Upload caddy binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
-      - name: Package caddy binary
-        if: github.event_name == 'release'
-        run: | # zizmor: ignore[template-injection]
-          tar -czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
-      - name: Upload to release
-        if: github.event_name == 'release'
-        run: | # zizmor: ignore[template-injection]
-          gh release upload ${{ github.event.release.tag_name }} ${{ matrix.artifact }}.tar.gz --repo ${{ github.repository }} --clobber
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-macos:
-    if: github.event_name != 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
           - os: macos-15
             artifact: caddy-darwin-arm64
           - os: macos-15-intel

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-linux:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -25,17 +25,77 @@ jobs:
         include:
           - os: ubuntu-22.04
             pybs_arch: x86_64_v2-unknown-linux-gnu
-            run_on_pr: true
           - os: ubuntu-22.04-arm
             pybs_arch: aarch64-unknown-linux-gnu
-            run_on_pr: true
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Build the server
+        working-directory: cmd/embed
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Retrieve python build standalone
+        if: ${{ !endsWith(matrix.python-version, '-nogil') }}
+        working-directory: cmd/embed
+        run: | # zizmor: ignore[template-injection]
+          python3 pybs.py latest --python-version ${{ matrix.python-version }} --architecture ${{ matrix.pybs_arch }} --build-config pgo+lto --content-type install_only_stripped
+          mv cpython-*.tar.gz python-standalone.tar.gz
+          go build main.go
+          mv main caddy
+      - name: Retrieve python build standalone (nogil)
+        if: ${{ endsWith(matrix.python-version, '-nogil') }}
+        working-directory: cmd/embed
+        run: | # zizmor: ignore[template-injection]
+          PY_VERSION_BASE="${{ matrix.python-version }}"
+          PY_VERSION_BASE="${PY_VERSION_BASE%-nogil}"
+          python3 pybs.py latest --python-version "${PY_VERSION_BASE}" --architecture ${{ matrix.pybs_arch }} --build-config freethreaded+pgo+lto --content-type full
+          tar -xf cpython-*.tar.zst
+          mv python/install .
+          rm -rf python
+          mv install python
+          tar -czf python-standalone.tar.gz python
+          go build main.go
+          mv main caddy
+      - name: Upload caddy standalone
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}
+          path: |
+            cmd/embed/caddy
+      - name: Package caddy standalone
+        if: github.event_name == 'release'
+        run: | # zizmor: ignore[template-injection]
+          tar -czf caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz cmd/embed/caddy
+      - name: Upload to release
+        if: github.event_name == 'release'
+        run: | # zizmor: ignore[template-injection]
+          gh release upload ${{ github.event.release.tag_name }} caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz --repo ${{ github.repository }} --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    if: github.event_name != 'pull_request'
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
+        include:
           - os: macos-15
             pybs_arch: aarch64-apple-darwin
-            run_on_pr: false
           - os: macos-15-intel
             pybs_arch: x86_64-apple-darwin
-            run_on_pr: false
-    if: matrix.run_on_pr || github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -1,4 +1,4 @@
-name: Caddy Standalone Linux
+name: Caddy Standalone
 
 on:
   pull_request:
@@ -22,7 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        include:
+          - os: ubuntu-22.04
+            pybs_arch: x86_64_v2-unknown-linux-gnu
+            run_on_pr: true
+          - os: ubuntu-22.04-arm
+            pybs_arch: aarch64-unknown-linux-gnu
+            run_on_pr: true
+          - os: macos-15
+            pybs_arch: aarch64-apple-darwin
+            run_on_pr: false
+          - os: macos-15-intel
+            pybs_arch: x86_64-apple-darwin
+            run_on_pr: false
+    if: matrix.run_on_pr || github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -37,15 +50,6 @@ jobs:
       - name: Build the server
         working-directory: cmd/embed
         run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
-      - name: Choose architecture
-        id: choose-arch
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-22.04-arm" ]; then
-            PYBS_ARCH=aarch64-unknown-linux-gnu
-          else
-            PYBS_ARCH=x86_64_v2-unknown-linux-gnu
-          fi
-          echo "PYBS_ARCH=${PYBS_ARCH}" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
@@ -53,7 +57,7 @@ jobs:
         if: ${{ !endsWith(matrix.python-version, '-nogil') }}
         working-directory: cmd/embed
         run: | # zizmor: ignore[template-injection]
-          python3 pybs.py latest --python-version ${{ matrix.python-version }} --architecture ${{ steps.choose-arch.outputs.PYBS_ARCH }} --build-config pgo+lto --content-type install_only_stripped
+          python3 pybs.py latest --python-version ${{ matrix.python-version }} --architecture ${{ matrix.pybs_arch }} --build-config pgo+lto --content-type install_only_stripped
           mv cpython-*.tar.gz python-standalone.tar.gz
           go build main.go
           mv main caddy
@@ -63,7 +67,7 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           PY_VERSION_BASE="${{ matrix.python-version }}"
           PY_VERSION_BASE="${PY_VERSION_BASE%-nogil}"
-          python3 pybs.py latest --python-version "${PY_VERSION_BASE}" --architecture ${{ steps.choose-arch.outputs.PYBS_ARCH }} --build-config freethreaded+pgo+lto --content-type full
+          python3 pybs.py latest --python-version "${PY_VERSION_BASE}" --architecture ${{ matrix.pybs_arch }} --build-config freethreaded+pgo+lto --content-type full
           tar -xf cpython-*.tar.zst
           mv python/install .
           rm -rf python
@@ -74,16 +78,16 @@ jobs:
       - name: Upload caddy standalone
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}
+          name: caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}
           path: |
             cmd/embed/caddy
       - name: Package caddy standalone
         if: github.event_name == 'release'
         run: | # zizmor: ignore[template-injection]
-          tar -czf caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}.tar.gz cmd/embed/caddy
+          tar -czf caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz cmd/embed/caddy
       - name: Upload to release
         if: github.event_name == 'release'
         run: | # zizmor: ignore[template-injection]
-          gh release upload ${{ github.event.release.tag_name }} caddy-standalone-${{ matrix.python-version }}-${{ steps.choose-arch.outputs.PYBS_ARCH }}.tar.gz --repo ${{ github.repository }} --clobber
+          gh release upload ${{ github.event.release.tag_name }} caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz --repo ${{ github.repository }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 jobs:
-  build-linux:
+  build:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -27,71 +27,6 @@ jobs:
             pybs_arch: x86_64_v2-unknown-linux-gnu
           - os: ubuntu-22.04-arm
             pybs_arch: aarch64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.26"
-          cache: false
-      - name: Install Xcaddy
-        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-      - name: Build the server
-        working-directory: cmd/embed
-        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.13"
-      - name: Retrieve python build standalone
-        if: ${{ !endsWith(matrix.python-version, '-nogil') }}
-        working-directory: cmd/embed
-        run: | # zizmor: ignore[template-injection]
-          python3 pybs.py latest --python-version ${{ matrix.python-version }} --architecture ${{ matrix.pybs_arch }} --build-config pgo+lto --content-type install_only_stripped
-          mv cpython-*.tar.gz python-standalone.tar.gz
-          go build main.go
-          mv main caddy
-      - name: Retrieve python build standalone (nogil)
-        if: ${{ endsWith(matrix.python-version, '-nogil') }}
-        working-directory: cmd/embed
-        run: | # zizmor: ignore[template-injection]
-          PY_VERSION_BASE="${{ matrix.python-version }}"
-          PY_VERSION_BASE="${PY_VERSION_BASE%-nogil}"
-          python3 pybs.py latest --python-version "${PY_VERSION_BASE}" --architecture ${{ matrix.pybs_arch }} --build-config freethreaded+pgo+lto --content-type full
-          tar -xf cpython-*.tar.zst
-          mv python/install .
-          rm -rf python
-          mv install python
-          tar -czf python-standalone.tar.gz python
-          go build main.go
-          mv main caddy
-      - name: Upload caddy standalone
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}
-          path: |
-            cmd/embed/caddy
-      - name: Package caddy standalone
-        if: github.event_name == 'release'
-        run: | # zizmor: ignore[template-injection]
-          tar -czf caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz cmd/embed/caddy
-      - name: Upload to release
-        if: github.event_name == 'release'
-        run: | # zizmor: ignore[template-injection]
-          gh release upload ${{ github.event.release.tag_name }} caddy-standalone-${{ matrix.python-version }}-${{ matrix.pybs_arch }}.tar.gz --repo ${{ github.repository }} --clobber
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-macos:
-    if: github.event_name != 'pull_request'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.13-nogil", "3.14", "3.14-nogil"]
-        include:
           - os: macos-15
             pybs_arch: aarch64-apple-darwin
           - os: macos-15-intel

--- a/.github/workflows/integration-tests-macos.yml
+++ b/.github/workflows/integration-tests-macos.yml
@@ -1,0 +1,70 @@
+name: Integration Tests macOS
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  tests:
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tool-name: ["flask", "simple_async"]
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Install Xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build caddy
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=../..
+      - name: Run integration tests
+        working-directory: tests/${{ matrix.tool-name }}/
+        run: |
+          chmod +x caddy
+          ./caddy run --config Caddyfile > caddy.log 2>&1 &
+          CADDY_PID=$!
+          deadline=$((SECONDS + 120))
+          while ! grep -q "finished cleaning storage units" caddy.log; do
+            if (( SECONDS >= deadline )); then
+              echo "Timed out waiting for Caddy"
+              cat caddy.log
+              exit 1
+            fi
+            sleep 1
+          done
+          source venv/bin/activate
+          python main_test.py 100
+          kill "$CADDY_PID" 2>/dev/null || true
+          wait "$CADDY_PID" 2>/dev/null || true
+      - name: Upload logs and report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: caddy-logs-macos-${{ matrix.tool-name }}-${{ matrix.python-version }}
+          path: |
+            tests/${{ matrix.tool-name }}/caddy.log

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,4 +1,4 @@
-name: Python Build Package - Linux
+name: Python Build Package
 
 on:
   push:
@@ -13,27 +13,43 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        include:
+          - os: ubuntu-22.04
+            docker_platform: linux/amd64
+            use_docker: true
+          - os: ubuntu-22.04-arm
+            docker_platform: linux/arm64
+            use_docker: true
+          - os: macos-15
+            use_docker: false
+          - os: macos-15-intel
+            use_docker: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Choose architecture
-        id: choose-arch
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-22.04-arm" ]; then
-            DOCKER_PLATFORM=linux/arm64
-          else
-            DOCKER_PLATFORM=linux/amd64
-          fi
-          echo "DOCKER_PLATFORM=${DOCKER_PLATFORM}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
+        if: matrix.use_docker
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
-      - name: Build Caddy with caddy-snake module
+      - name: Build Caddy with caddy-snake module (Docker)
+        if: matrix.use_docker
         run: | # zizmor: ignore[template-injection]
-          docker build -f builder.Dockerfile --platform ${{ steps.choose-arch.outputs.DOCKER_PLATFORM }} --build-arg PY_VERSION=${{ matrix.python-version }} -t caddy-snake-builder .
+          docker build -f builder.Dockerfile --platform ${{ matrix.docker_platform }} --build-arg PY_VERSION=${{ matrix.python-version }} -t caddy-snake-builder .
           docker run --rm -v $(pwd):/output caddy-snake-builder
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        if: ${{ !matrix.use_docker }}
+        with:
+          go-version: "1.26"
+          cache: false
+      - name: Build Caddy with caddy-snake module (native)
+        if: ${{ !matrix.use_docker }}
+        run: |
+          go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+          CGO_ENABLED=0 xcaddy build --with github.com/mliezun/caddy-snake=.
+      - name: Install Rust
+        if: ${{ !matrix.use_docker }}
+        run: rustup toolchain install stable
       - name: Setup Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,7 @@ hey -c 100 -z 10s http://localhost:9080/hello
 
 ## Releases
 
-Patch releases use semantic tags `v0.x.y` on `main`. Publishing a release triggers CI to build and attach Linux binaries (see `.github/workflows/build-binary.yml`, `build-standalone.yml`, `python-build.yml`, `docker-publish.yml`).
+Patch releases use semantic tags `v0.x.y` on `main`. Publishing a release triggers CI to build and attach Linux and macOS binaries (see `.github/workflows/build-binary.yml`, `build-standalone.yml`, `python-build.yml`, `docker-publish.yml`).
 
 ### Checklist
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Caddy Snake 🐍
 
 [![Integration Tests Linux](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-linux.yml/badge.svg)](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-linux.yml)
+[![Integration Tests macOS](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-macos.yml/badge.svg)](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-macos.yml)
 [![Integration Tests Windows](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-windows.yml/badge.svg)](https://github.com/mliezun/caddy-snake/actions/workflows/integration-tests-windows.yml)
 [![Go Coverage](https://github.com/mliezun/caddy-snake/wiki/coverage.svg)](https://raw.githack.com/wiki/mliezun/caddy-snake/coverage.html)
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://caddy-snake.readthedocs.io/en/latest/)

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -10,7 +10,7 @@ The `caddysnake` package is available on [PyPI](https://pypi.org/project/caddysn
 pip install caddysnake
 ```
 
-Available for Python 3.12 through 3.14 on Linux (x86_64 and ARM64).
+Available for Python 3.12 through 3.14 on Linux and macOS (x86_64 and ARM64).
 
 ## Usage
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -20,7 +20,7 @@ The [`caddysnake`](https://pypi.org/project/caddysnake/) package on PyPI is the 
 pip install caddysnake
 ```
 
-**Requirements:** Python >= 3.12, Linux (x86_64 or ARM64)
+**Requirements:** Python >= 3.12, Linux (x86_64 or ARM64) or macOS (x86_64 or ARM64)
 
 Available Python versions: 3.12, 3.13, 3.14
 
@@ -99,6 +99,8 @@ caddy-standalone-{python-version}-{architecture}.tar.gz
 For example:
 - `caddy-standalone-3.13-x86_64_v2-unknown-linux-gnu.tar.gz` — Python 3.13, Linux x86_64
 - `caddy-standalone-3.13-aarch64-unknown-linux-gnu.tar.gz` — Python 3.13, Linux ARM64
+- `caddy-standalone-3.13-x86_64-apple-darwin.tar.gz` — Python 3.13, macOS Intel
+- `caddy-standalone-3.13-aarch64-apple-darwin.tar.gz` — Python 3.13, macOS Apple Silicon
 - `caddy-standalone-3.13-nogil-x86_64_v2-unknown-linux-gnu.tar.gz` — Python 3.13 free-threaded
 - `caddy-standalone-3.14-nogil-x86_64_v2-unknown-linux-gnu.tar.gz` — Python 3.14 free-threaded
 
@@ -106,11 +108,11 @@ For example:
 
 | Python | Architectures | Notes |
 |--------|--------------|-------|
-| 3.12 | x86_64, ARM64 | |
-| 3.13 | x86_64, ARM64 | |
-| 3.13-nogil | x86_64, ARM64 | Free-threaded (PEP 703) |
-| 3.14 | x86_64, ARM64 | |
-| 3.14-nogil | x86_64, ARM64 | Free-threaded (PEP 703) |
+| 3.12 | Linux x86_64, Linux ARM64, macOS x86_64, macOS ARM64 | |
+| 3.13 | Linux x86_64, Linux ARM64, macOS x86_64, macOS ARM64 | |
+| 3.13-nogil | Linux x86_64, Linux ARM64, macOS x86_64, macOS ARM64 | Free-threaded (PEP 703) |
+| 3.14 | Linux x86_64, Linux ARM64, macOS x86_64, macOS ARM64 | |
+| 3.14-nogil | Linux x86_64, Linux ARM64, macOS x86_64, macOS ARM64 | Free-threaded (PEP 703) |
 
 ### Usage
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -22,7 +22,7 @@ pip install caddysnake
 
 This installs the `caddysnake` command, which is a thin wrapper around a pre-compiled Caddy binary with the caddy-snake plugin. No C compiler or manual build step required — workers use the Python interpreter from your environment.
 
-Available on [PyPI](https://pypi.org/project/caddysnake/) for Python 3.12 through 3.14 on Linux (x86_64 and ARM64).
+Available on [PyPI](https://pypi.org/project/caddysnake/) for Python 3.12 through 3.14 on Linux and macOS (x86_64 and ARM64).
 
 ### Usage
 
@@ -79,7 +79,7 @@ tar -xzf caddy-standalone-3.13-x86_64_v2-unknown-linux-gnu.tar.gz
 ./caddy python-server --server-type wsgi --app main:app
 ```
 
-Pre-built binaries are available for Python 3.12 through 3.14 (including 3.13-nogil and 3.14-nogil) on Linux x86_64 and ARM64. See the [Pre-built Binaries](installation.md#pre-built-standalone-binaries) page for details on how they work.
+Pre-built binaries are available for Python 3.12 through 3.14 (including 3.13-nogil and 3.14-nogil) on Linux and macOS (x86_64 and ARM64). See the [Pre-built Binaries](installation.md#pre-built-standalone-binaries) page for details on how they work.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extend `build-binary`, `build-standalone`, and `python-build` workflows with `macos-15` (ARM64) and `macos-15-intel` (x86_64) runners
- Upload macOS plugin binaries (`caddy-darwin-*`) and standalone tarballs (`*-apple-darwin`) to GitHub Releases on publish
- Build and publish macOS PyPI wheels via native `xcaddy` + `maturin` (Linux still uses the Docker builder)
- Skip macOS jobs on pull requests to limit runner cost; they run on push to `main`, releases, and version tags
- Update docs and AGENTS.md to reflect macOS distribution support

## Test plan
- [x] Merge and verify Linux PR checks still pass (`build-binary`, `build-standalone`)
- [x] Push to `main` and confirm macOS jobs run in `build-binary` / `build-standalone`
- [x] Cut a release tag and verify macOS artifacts appear on the release page
- [x] Confirm `python-build` publishes macOS wheels to PyPI on the next tag

Made with [Cursor](https://cursor.com)