### PR TITLE
Fix path-prefixed python blocks being ordered after route

### DIFF
--- a/caddysnake.go
+++ b/caddysnake.go
@@ -807,7 +807,7 @@ func (wg *PythonWorkerGroup) HandleRequest(rw http.ResponseWriter, req *http.Req
 func init() {
 	caddy.RegisterModule(CaddySnake{})
 	httpcaddyfile.RegisterHandlerDirective("python", parsePythonDirective)
-	httpcaddyfile.RegisterDirectiveOrder("python", httpcaddyfile.Before, "respond")
+	httpcaddyfile.RegisterDirectiveOrder("python", httpcaddyfile.Before, "route")
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name: "python-server",
 		Usage: "--server-type wsgi|asgi|esgi --app <module> " +

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -1839,26 +1839,46 @@ func TestPythonDirectiveCaddyfileRouteOrder(t *testing.T) {
 		t.Fatal("expected at least one route")
 	}
 
-	firstPython := -1
-	firstFileServer := -1
+	var pythonIdxs []int
+	lastFileServer := -1
 	for i, routeRaw := range routes {
 		routeStr := string(routeRaw)
-		if firstPython < 0 && strings.Contains(routeStr, `"handler":"python"`) {
-			firstPython = i
+		if strings.Contains(routeStr, `"handler":"python"`) {
+			pythonIdxs = append(pythonIdxs, i)
 		}
-		if firstFileServer < 0 && strings.Contains(routeStr, `"handler":"file_server"`) {
-			firstFileServer = i
+		if strings.Contains(routeStr, `"handler":"file_server"`) {
+			lastFileServer = i
 		}
 	}
-	if firstPython < 0 {
-		t.Fatalf("no python route found in adapted config:\n%s", string(out))
+
+	// All three path-prefixed python blocks must be present.
+	if len(pythonIdxs) != 3 {
+		t.Fatalf("expected 3 python routes, found %d:\n%s", len(pythonIdxs), string(out))
 	}
-	if firstFileServer < 0 {
+	if lastFileServer < 0 {
 		t.Fatalf("no file_server route found in adapted config:\n%s", string(out))
 	}
-	if firstPython > firstFileServer {
-		t.Fatalf("python route at index %d should come before file_server at index %d\n%s",
-			firstPython, firstFileServer, string(out))
+
+	// Every python route must come before the catch-all file_server route.
+	for _, idx := range pythonIdxs {
+		if idx > lastFileServer {
+			t.Fatalf("python route at index %d should come before file_server at index %d\n%s",
+				idx, lastFileServer, string(out))
+		}
+	}
+
+	// Sanity check: each expected path is routed to python.
+	for _, path := range []string{"/docs", "/openapi.json", "/api/v1/*"} {
+		found := false
+		for _, idx := range pythonIdxs {
+			if strings.Contains(string(routes[idx]), path) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a python route matching %q\n%s", path, string(out))
+		}
 	}
 }
 

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -1791,6 +1791,77 @@ func TestPythonDirectiveCaddyfileAdaptation(t *testing.T) {
 	}
 }
 
+func TestPythonDirectiveCaddyfileRouteOrder(t *testing.T) {
+	// Regression for #179: path-prefixed python blocks must be evaluated before
+	// a catch-all route block (e.g. SPA file_server), not after it.
+	input := `:9000 {
+		encode
+		python /docs {
+			module_asgi "__init__:app"
+		}
+		python /openapi.json {
+			module_asgi "__init__:app"
+		}
+		python /api/v1/* {
+			module_asgi "__init__:app"
+		}
+		route {
+			root * /web/dist
+			try_files {path} /index.html
+			file_server
+		}
+	}`
+	adapter := caddyfile.Adapter{ServerType: httpcaddyfile.ServerType{}}
+	out, _, err := adapter.Adapt([]byte(input), nil)
+	if err != nil {
+		t.Fatalf("unexpected adaptation error: %v", err)
+	}
+
+	var cfg struct {
+		Apps struct {
+			HTTP struct {
+				Servers map[string]struct {
+					Routes []json.RawMessage `json:"routes"`
+				} `json:"servers"`
+			} `json:"http"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatalf("unmarshal adapted config: %v", err)
+	}
+
+	var routes []json.RawMessage
+	for _, srv := range cfg.Apps.HTTP.Servers {
+		routes = srv.Routes
+		break
+	}
+	if len(routes) == 0 {
+		t.Fatal("expected at least one route")
+	}
+
+	firstPython := -1
+	firstFileServer := -1
+	for i, routeRaw := range routes {
+		routeStr := string(routeRaw)
+		if firstPython < 0 && strings.Contains(routeStr, `"handler":"python"`) {
+			firstPython = i
+		}
+		if firstFileServer < 0 && strings.Contains(routeStr, `"handler":"file_server"`) {
+			firstFileServer = i
+		}
+	}
+	if firstPython < 0 {
+		t.Fatalf("no python route found in adapted config:\n%s", string(out))
+	}
+	if firstFileServer < 0 {
+		t.Fatalf("no file_server route found in adapted config:\n%s", string(out))
+	}
+	if firstPython > firstFileServer {
+		t.Fatalf("python route at index %d should come before file_server at index %d\n%s",
+			firstPython, firstFileServer, string(out))
+	}
+}
+
 func TestDynamicAppResolveWithNilReplacer(t *testing.T) {
 	d, _ := NewDynamicApp("main:app", "/home/static", "",
 		func(module, dir, venv string) (AppServer, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #179.

Path-prefixed `python` blocks (e.g. `python /docs { ... }`) were incorrectly sorted **after** `route` blocks during Caddyfile adaptation. When a catch-all `route { file_server }` was present, it matched every request before the Python handlers could run.

The `python` directive was registered to run before `respond`, but `route` comes earlier in Caddy's default directive order. This change registers `python` before `route` so path-prefixed handlers are evaluated first.

## Changes

- Register `python` directive order before `route` instead of `respond` (still before `respond` transitively)
- Add regression test `TestPythonDirectiveCaddyfileRouteOrder` that verifies Python routes appear before `file_server` in adapted config

## Test plan

- [x] `go test -race -v .`
- [x] New `TestPythonDirectiveCaddyfileRouteOrder` passes
- [x] Existing `TestPythonDirectiveCaddyfileAdaptation` cases still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c7130dc-c9d6-44d7-a403-a2b7634d8788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c7130dc-c9d6-44d7-a403-a2b7634d8788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

