### PR TITLE
Fix PyPI wheel matrix to build all Linux and macOS platforms

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-15, macos-15-intel]
         include:
           - os: ubuntu-22.04
             docker_platform: linux/amd64


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incomplete PyPI wheels for v0.5.8 (only 3 macOS x86_64 wheels published).

When `os` was only listed under `matrix.include`, GitHub Actions applied the **last** include entry (`macos-15-intel`) to every `python-version` job. The v0.5.8 release run had only 3 build jobs (all on `macos-15-intel`) instead of the expected 12 (4 platforms × 3 Python versions).

## Fix

Add `os` to the base matrix (matching `build-standalone.yml`) and keep `include` only for per-OS settings (`use_docker`, `docker_platform`).

## After merge

Re-publish wheels for v0.5.8 via workflow dispatch (`Python Build Package` with tag `v0.5.8`). `skip-existing: true` will keep the existing macOS x86_64 wheels and upload the missing Linux and macOS ARM wheels.

## Test plan

- [ ] Merge and trigger `Python Build Package` workflow dispatch with tag `v0.5.8`
- [ ] Confirm 12 build jobs run (ubuntu-22.04, ubuntu-22.04-arm, macos-15, macos-15-intel × 3.12/3.13/3.14)
- [ ] Confirm PyPI shows linux x86_64, linux aarch64, macOS x86_64, and macOS arm64 wheels

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c7130dc-c9d6-44d7-a403-a2b7634d8788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c7130dc-c9d6-44d7-a403-a2b7634d8788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

