### PR TITLE
Add env_file and env_var directives to python block

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ python {
     runtime sync|gevent|native|uvloop   # See table; ESGI allows gevent only
     venv "/path/to/venv"                # Virtual environment path
     working_dir "/path/to/app"          # Working directory for module resolution
+    env_file "/path/to/.env"            # Dotenv file loaded into worker env (repeatable)
+    env_var VARNAME value               # Inline env var; overrides env_file (repeatable)
     workers 4                           # Number of worker processes (default: CPU count)
     lifespan on|off                     # ASGI lifespan events (default: off)
     autoreload                          # Watch .py files and reload on changes
@@ -297,6 +299,36 @@ python {
 }
 ```
 
+### `env_file`
+
+Path to a dotenv-style file whose variables are loaded into each Python worker process for this `python` block. You may specify `env_file` more than once; later files override earlier ones for duplicate keys.
+
+Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory.
+
+```Caddyfile
+python {
+    module_wsgi "main:app"
+    working_dir "/var/www/myapp"
+    env_file "/var/www/myapp/.env"
+}
+```
+
+### `env_var`
+
+Set a single environment variable inline. Repeat to set multiple variables. **`env_var` values apply after `env_file`**, so they override variables from files when the name matches.
+
+```Caddyfile
+python {
+    module_asgi "main:app"
+    working_dir "/var/www/myapp"
+    env_file "/var/www/myapp/.env"
+    env_var DEBUG "1"
+    env_var DATABASE_URL "postgres://localhost/myapp_dev"
+}
+```
+
+**Precedence:** Caddy process environment → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`). Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) cannot be set from the Caddyfile.
+
 ### `workers`
 
 Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`).
@@ -346,7 +378,7 @@ Thread workers and single-worker setups do not need this path. See the docs for 
 
 ## Dynamic module loading
 
-You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, and `venv` to dynamically load different Python apps based on the request.
+You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, `venv`, `env_file`, and `env_var` **values** to dynamically load different Python apps based on the request.
 
 This is useful for multi-tenant setups where each subdomain or route serves a different application:
 

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -86,7 +86,9 @@ type CaddySnake struct {
 	VenvPath   string `json:"venv_path,omitempty"`
 	Workers    string `json:"workers,omitempty"`
 	Autoreload string `json:"autoreload,omitempty"`
-	PythonPath string `json:"python_path,omitempty"`
+	PythonPath string            `json:"python_path,omitempty"`
+	EnvFiles   []string          `json:"env_files,omitempty"`
+	EnvVars    map[string]string `json:"env_vars,omitempty"`
 	logger     *zap.Logger
 	app        AppServer
 	cacheSrv   *cacheServer
@@ -178,6 +180,24 @@ func (f *CaddySnake) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					if !d.Args(&f.PythonPath) {
 						return d.Errf("expected exactly one argument for python_path")
 					}
+				case "env_file":
+					var path string
+					if !d.Args(&path) {
+						return d.Errf("expected exactly one argument for env_file")
+					}
+					f.EnvFiles = append(f.EnvFiles, path)
+				case "env_var":
+					var name, value string
+					if !d.Args(&name, &value) {
+						return d.Errf("expected exactly two arguments for env_var: VARNAME value")
+					}
+					if err := validateEnvVarName(name); err != nil {
+						return d.Errf("invalid env_var name %q: %v", name, err)
+					}
+					if f.EnvVars == nil {
+						f.EnvVars = make(map[string]string)
+					}
+					f.EnvVars[name] = value
 				default:
 					return d.Errf("unknown subdirective: %s", d.Val())
 				}
@@ -223,7 +243,8 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 
 	isDynamic := containsPlaceholder(f.ModuleWsgi) || containsPlaceholder(f.ModuleAsgi) ||
 		containsPlaceholder(f.ModuleEsgi) ||
-		containsPlaceholder(f.WorkingDir) || containsPlaceholder(f.VenvPath)
+		containsPlaceholder(f.WorkingDir) || containsPlaceholder(f.VenvPath) ||
+		envFilesContainPlaceholder(f.EnvFiles) || envMapContainsPlaceholder(f.EnvVars)
 
 	if isDynamic {
 		if err = f.provisionDynamic(workers, cacheAddr); err != nil {
@@ -235,9 +256,12 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 
 	pythonBin := resolvePythonInterpreter(f.PythonPath, f.VenvPath)
 
+	envFiles := cloneEnvFiles(f.EnvFiles)
+	envVars := cloneEnvVars(f.EnvVars)
+
 	if f.ModuleWsgi != "" {
 		rt := effectivePythonRuntime("wsgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr)
+		f.app, err = NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		if err != nil {
 			return err
 		}
@@ -247,14 +271,14 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 		f.logger.Info("serving wsgi app", zap.String("module_wsgi", f.ModuleWsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
 	} else if f.ModuleAsgi != "" {
 		rt := effectivePythonRuntime("asgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr)
+		f.app, err = NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		if err != nil {
 			return err
 		}
 		f.logger.Info("serving asgi app", zap.String("module_asgi", f.ModuleAsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
 	} else if f.ModuleEsgi != "" {
 		rt := effectivePythonRuntime("esgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr)
+		f.app, err = NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		if err != nil {
 			return err
 		}
@@ -280,17 +304,17 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 		if f.ModuleWsgi != "" {
 			rt := effectivePythonRuntime("wsgi", f.Runtime)
 			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr)
+				return NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 			}
 		} else if f.ModuleAsgi != "" {
 			rt := effectivePythonRuntime("asgi", f.Runtime)
 			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr)
+				return NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 			}
 		} else {
 			rt := effectivePythonRuntime("esgi", f.Runtime)
 			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr)
+				return NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 			}
 		}
 
@@ -310,16 +334,18 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 func (f *CaddySnake) provisionDynamic(workers int, cacheAddr string) error {
 	autoreload := f.Autoreload == "on"
 	pythonPath := f.PythonPath
+	envFilePatterns := cloneEnvFiles(f.EnvFiles)
+	envVarPatterns := cloneEnvVars(f.EnvVars)
 
 	if f.ModuleWsgi != "" {
 		lifespan := f.Lifespan
 		rt := effectivePythonRuntime("wsgi", f.Runtime)
-		factory := func(module, dir, venv string) (AppServer, error) {
+		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("wsgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr)
+			return NewPythonWorkerGroup("wsgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		}
 		var err error
-		f.app, err = NewDynamicApp(f.ModuleWsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
+		f.app, err = NewDynamicApp(f.ModuleWsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
 		if err != nil {
 			return err
 		}
@@ -334,12 +360,12 @@ func (f *CaddySnake) provisionDynamic(workers int, cacheAddr string) error {
 	} else if f.ModuleAsgi != "" {
 		lifespan := f.Lifespan
 		rt := effectivePythonRuntime("asgi", f.Runtime)
-		factory := func(module, dir, venv string) (AppServer, error) {
+		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("asgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr)
+			return NewPythonWorkerGroup("asgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		}
 		var err error
-		f.app, err = NewDynamicApp(f.ModuleAsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
+		f.app, err = NewDynamicApp(f.ModuleAsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
 		if err != nil {
 			return err
 		}
@@ -350,12 +376,12 @@ func (f *CaddySnake) provisionDynamic(workers int, cacheAddr string) error {
 		)
 	} else if f.ModuleEsgi != "" {
 		rt := effectivePythonRuntime("esgi", f.Runtime)
-		factory := func(module, dir, venv string) (AppServer, error) {
+		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("esgi", module, dir, venv, "", rt, workers, pythonBin, cacheAddr)
+			return NewPythonWorkerGroup("esgi", module, dir, venv, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars)
 		}
 		var err error
-		f.app, err = NewDynamicApp(f.ModuleEsgi, f.WorkingDir, f.VenvPath, factory, f.logger, autoreload, nil)
+		f.app, err = NewDynamicApp(f.ModuleEsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
 		if err != nil {
 			return err
 		}
@@ -408,6 +434,9 @@ func (m *CaddySnake) Validate() error {
 	}
 	if m.Lifespan != "" && m.Lifespan != "on" && m.Lifespan != "off" {
 		return fmt.Errorf("lifespan must be 'on' or 'off', got: %s", m.Lifespan)
+	}
+	if err := validateEnvVars(m.EnvVars); err != nil {
+		return err
 	}
 	return nil
 }
@@ -537,13 +566,15 @@ type PythonWorker struct {
 	DialNet    string // "unix" or "tcp"
 	DialAddr   string // socket path or host:port
 	CacheAddr  string // CADDYSNAKE_CACHE_ADDR: unix://path (Unix) or 127.0.0.1:port (Windows); empty = omit env
+	EnvFiles   []string
+	EnvVars    map[string]string
 
 	Cmd       *exec.Cmd
 	Transport *http.Transport
 	Proxy     *httputil.ReverseProxy
 }
 
-func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBin, scriptPath, cacheAddr string) (*PythonWorker, error) {
+func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBin, scriptPath, cacheAddr string, envFiles []string, envVars map[string]string) (*PythonWorker, error) {
 	var socket *os.File
 	var sockDir string
 	var err error
@@ -590,6 +621,8 @@ func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBi
 		DialNet:    dialNet,
 		DialAddr:   dialAddr,
 		CacheAddr:  cacheAddr,
+		EnvFiles:   cloneEnvFiles(envFiles),
+		EnvVars:    cloneEnvVars(envVars),
 	}
 	err = w.Start()
 	return w, err
@@ -640,15 +673,11 @@ func (w *PythonWorker) Start() error {
 	w.Cmd = exec.Command(w.PythonBin, args...)
 	w.Cmd.Stdout = os.Stdout
 	w.Cmd.Stderr = os.Stderr
-	env := append(os.Environ(), "PYTHONUNBUFFERED=1")
-	if w.CacheAddr != "" {
-		env = append(env,
-			EnvCaddysnakeCacheAddr+"="+w.CacheAddr,
-			EnvCaddysnakeWorkerInterface+"="+w.Interface,
-			EnvCaddysnakeCacheTimeoutSeconds+"="+strconv.Itoa(DefaultCacheClientTimeoutSec),
-		)
+	fileVars, err := loadEnvFiles(w.WorkingDir, w.EnvFiles)
+	if err != nil {
+		return err
 	}
-	w.Cmd.Env = env
+	w.Cmd.Env = buildWorkerEnv(os.Environ(), fileVars, w.EnvVars, workerInternalEnv(w.Interface, w.CacheAddr)...)
 	setSysProcAttr(w.Cmd)
 
 	if err := w.Cmd.Start(); err != nil {
@@ -759,7 +788,7 @@ type PythonWorkerGroup struct {
 	ScriptPath string // path to worker_main.py inside BundleDir
 }
 
-func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string, count int, pythonBin, cacheAddr string) (*PythonWorkerGroup, error) {
+func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string, count int, pythonBin, cacheAddr string, envFiles []string, envVars map[string]string) (*PythonWorkerGroup, error) {
 	scriptPath, bundleDir, err := writeCaddysnakePyBundle()
 	if err != nil {
 		return nil, fmt.Errorf("failed to write worker bundle: %w", err)
@@ -768,7 +797,7 @@ func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string
 	errs := make([]error, count)
 	workers := make([]*PythonWorker, count)
 	for i := 0; i < count; i++ {
-		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, runtime, pythonBin, scriptPath, cacheAddr)
+		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, runtime, pythonBin, scriptPath, cacheAddr, envFiles, envVars)
 	}
 	wg := &PythonWorkerGroup{
 		Workers:    workers,

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -139,8 +139,8 @@ func TestValidateResolvedValues(t *testing.T) {
 }
 
 func TestDynamicAppResolveWithoutReplacer(t *testing.T) {
-	d, _ := NewDynamicApp("main:app", "/home/{host.labels.0}", "/venvs/{host.labels.0}",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/{host.labels.0}", "/venvs/{host.labels.0}", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, nil
 		},
 		zap.NewNop(),
@@ -151,7 +151,7 @@ func TestDynamicAppResolveWithoutReplacer(t *testing.T) {
 	r := &http.Request{}
 	r = r.WithContext(context.Background())
 
-	key, module, dir, venv := d.resolve(r)
+	key, module, dir, venv, _, _ := d.resolve(r)
 
 	if module != "main:app" {
 		t.Errorf("expected module 'main:app', got %q", module)
@@ -162,7 +162,7 @@ func TestDynamicAppResolveWithoutReplacer(t *testing.T) {
 	if venv != "/venvs/{host.labels.0}" {
 		t.Errorf("expected venv '/venvs/{host.labels.0}', got %q", venv)
 	}
-	expectedKey := "main:app|/home/{host.labels.0}|/venvs/{host.labels.0}"
+	expectedKey := "main:app|/home/{host.labels.0}|/venvs/{host.labels.0}||"
 	if key != expectedKey {
 		t.Errorf("expected key %q, got %q", expectedKey, key)
 	}
@@ -172,8 +172,8 @@ func TestDynamicAppGetOrCreate(t *testing.T) {
 	var createCount int
 	mockApp := &mockAppServer{}
 
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			createCount++
 			return mockApp, nil
 		},
@@ -182,7 +182,7 @@ func TestDynamicAppGetOrCreate(t *testing.T) {
 		nil,
 	)
 
-	app1, err := d.getOrCreateApp("key1", "main:app", "/home/test", "")
+	app1, err := d.getOrCreateApp("key1", "main:app", "/home/test", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestDynamicAppGetOrCreate(t *testing.T) {
 		t.Errorf("expected factory to be called once, got %d", createCount)
 	}
 
-	app2, err := d.getOrCreateApp("key1", "main:app", "/home/test", "")
+	app2, err := d.getOrCreateApp("key1", "main:app", "/home/test", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestDynamicAppGetOrCreate(t *testing.T) {
 		t.Errorf("expected factory to still be called once, got %d", createCount)
 	}
 
-	_, err = d.getOrCreateApp("key2", "main:app", "/home/other", "")
+	_, err = d.getOrCreateApp("key2", "main:app", "/home/other", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -215,8 +215,8 @@ func TestDynamicAppGetOrCreate(t *testing.T) {
 
 func TestDynamicAppCleanup(t *testing.T) {
 	var cleanupCount int
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return &mockAppServer{onCleanup: func() { cleanupCount++ }}, nil
 		},
 		zap.NewNop(),
@@ -224,8 +224,8 @@ func TestDynamicAppCleanup(t *testing.T) {
 		nil,
 	)
 
-	_, _ = d.getOrCreateApp("key1", "main:app", "/home/a", "")
-	_, _ = d.getOrCreateApp("key2", "main:app", "/home/b", "")
+	_, _ = d.getOrCreateApp("key1", "main:app", "/home/a", "", nil, nil)
+	_, _ = d.getOrCreateApp("key2", "main:app", "/home/b", "", nil, nil)
 
 	err := d.Cleanup()
 	if err != nil {
@@ -895,8 +895,8 @@ func TestWriteCaddysnakePyBundle(t *testing.T) {
 
 func TestDynamicAppGetOrCreate_FactoryError(t *testing.T) {
 	factoryErr := errors.New("import failed")
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, factoryErr
 		},
 		zap.NewNop(),
@@ -904,7 +904,7 @@ func TestDynamicAppGetOrCreate_FactoryError(t *testing.T) {
 		nil,
 	)
 
-	app, err := d.getOrCreateApp("key1", "main:app", "/home/test", "")
+	app, err := d.getOrCreateApp("key1", "main:app", "/home/test", "", nil, nil)
 	if err != factoryErr {
 		t.Errorf("expected factory error, got: %v", err)
 	}
@@ -921,8 +921,8 @@ func TestDynamicAppGetOrCreate_FactoryError(t *testing.T) {
 
 func TestDynamicAppCleanup_WithErrors(t *testing.T) {
 	cleanupErr := errors.New("cleanup failed")
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return &mockAppServer{cleanupErr: cleanupErr}, nil
 		},
 		zap.NewNop(),
@@ -930,8 +930,8 @@ func TestDynamicAppCleanup_WithErrors(t *testing.T) {
 		nil,
 	)
 
-	_, _ = d.getOrCreateApp("key1", "main:app", "/home/a", "")
-	_, _ = d.getOrCreateApp("key2", "main:app", "/home/b", "")
+	_, _ = d.getOrCreateApp("key1", "main:app", "/home/a", "", nil, nil)
+	_, _ = d.getOrCreateApp("key2", "main:app", "/home/b", "", nil, nil)
 
 	err := d.Cleanup()
 	if err == nil {
@@ -950,8 +950,8 @@ func TestDynamicAppHandleRequest(t *testing.T) {
 			return nil
 		},
 	}
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			handledModule = module
 			handledDir = dir
 			return mockApp, nil
@@ -979,8 +979,8 @@ func TestDynamicAppHandleRequest(t *testing.T) {
 
 func TestDynamicAppHandleRequest_FactoryError(t *testing.T) {
 	factoryErr := errors.New("import failed")
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, factoryErr
 		},
 		zap.NewNop(),
@@ -1007,8 +1007,8 @@ func TestDynamicAppHandleRequest_AutoreloadFactoryError_TerminatesWhenExitFuncSe
 		close(exitCalled)
 	}
 
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, factoryErr
 		},
 		zap.NewNop(),
@@ -1034,8 +1034,8 @@ func TestDynamicAppHandleRequest_AutoreloadFactoryError_TerminatesWhenExitFuncSe
 }
 
 func TestDynamicAppResolveWithReplacer(t *testing.T) {
-	d, _ := NewDynamicApp("main:app", "/home/{custom.host}", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/{custom.host}", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, nil
 		},
 		zap.NewNop(),
@@ -1049,7 +1049,7 @@ func TestDynamicAppResolveWithReplacer(t *testing.T) {
 	r := &http.Request{}
 	r = r.WithContext(ctx)
 
-	key, module, dir, venv := d.resolve(r)
+	key, module, dir, venv, _, _ := d.resolve(r)
 	if module != "main:app" {
 		t.Errorf("expected module 'main:app', got %q", module)
 	}
@@ -1059,15 +1059,15 @@ func TestDynamicAppResolveWithReplacer(t *testing.T) {
 	if venv != "" {
 		t.Errorf("expected empty venv, got %q", venv)
 	}
-	expectedKey := "main:app|/home/sub1.example.com|"
+	expectedKey := "main:app|/home/sub1.example.com|||"
 	if key != expectedKey {
 		t.Errorf("expected key %q, got %q", expectedKey, key)
 	}
 }
 
 func TestDynamicAppResolveMultiplePlaceholders(t *testing.T) {
-	d, _ := NewDynamicApp("{custom.module}:app", "/home/{custom.host}", "/venvs/{custom.host}",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("{custom.module}:app", "/home/{custom.host}", "/venvs/{custom.host}", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, nil
 		},
 		zap.NewNop(),
@@ -1082,7 +1082,7 @@ func TestDynamicAppResolveMultiplePlaceholders(t *testing.T) {
 	r := &http.Request{}
 	r = r.WithContext(ctx)
 
-	key, module, dir, venv := d.resolve(r)
+	key, module, dir, venv, _, _ := d.resolve(r)
 	if module != "mymod:app" {
 		t.Errorf("expected module 'mymod:app', got %q", module)
 	}
@@ -1092,7 +1092,7 @@ func TestDynamicAppResolveMultiplePlaceholders(t *testing.T) {
 	if venv != "/venvs/tenant1" {
 		t.Errorf("expected venv '/venvs/tenant1', got %q", venv)
 	}
-	expectedKey := "mymod:app|/home/tenant1|/venvs/tenant1"
+	expectedKey := "mymod:app|/home/tenant1|/venvs/tenant1||"
 	if key != expectedKey {
 		t.Errorf("expected key %q, got %q", expectedKey, key)
 	}
@@ -1101,8 +1101,8 @@ func TestDynamicAppResolveMultiplePlaceholders(t *testing.T) {
 func TestDynamicAppConcurrentAccess(t *testing.T) {
 	var mu sync.Mutex
 	createCount := 0
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			mu.Lock()
 			createCount++
 			mu.Unlock()
@@ -1140,8 +1140,8 @@ func TestDynamicAppConcurrentAccess(t *testing.T) {
 func TestDynamicAppConcurrentDifferentKeys(t *testing.T) {
 	var mu sync.Mutex
 	createdKeys := make(map[string]bool)
-	d, _ := NewDynamicApp("main:app", "", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			mu.Lock()
 			createdKeys[module+"|"+dir+"|"+venv] = true
 			mu.Unlock()
@@ -1158,7 +1158,7 @@ func TestDynamicAppConcurrentDifferentKeys(t *testing.T) {
 		key := fmt.Sprintf("key%d", i)
 		dir := fmt.Sprintf("/home/dir%d", i)
 		go func(k, dirPath string) {
-			_, err := d.getOrCreateApp(k, "main:app", dirPath, "")
+			_, err := d.getOrCreateApp(k, "main:app", dirPath, "", nil, nil)
 			errs <- err
 		}(key, dir)
 	}
@@ -1350,8 +1350,8 @@ func TestDynamicAppGetOrCreate_DoubleCheckPath(t *testing.T) {
 	factoryCalls := int32(0)
 	mockApp := &mockAppServer{}
 
-	d, _ := NewDynamicApp("main:app", "/home/test", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			atomic.AddInt32(&factoryCalls, 1)
 			time.Sleep(10 * time.Millisecond)
 			return mockApp, nil
@@ -1369,7 +1369,7 @@ func TestDynamicAppGetOrCreate_DoubleCheckPath(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			barrier.Wait()
-			_, err := d.getOrCreateApp("key1", "main:app", "/home/test", "")
+			_, err := d.getOrCreateApp("key1", "main:app", "/home/test", "", nil, nil)
 			errs <- err
 		}()
 	}
@@ -1388,8 +1388,8 @@ func TestDynamicAppGetOrCreate_DoubleCheckPath(t *testing.T) {
 }
 
 func TestDynamicAppCleanup_EmptyApps(t *testing.T) {
-	d, _ := NewDynamicApp("main:app", "", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return &mockAppServer{}, nil
 		},
 		zap.NewNop(),
@@ -1586,7 +1586,7 @@ func TestNewPythonWorkerGroup_InvalidPythonPath(t *testing.T) {
 	tempDir := t.TempDir()
 	os.WriteFile(filepath.Join(tempDir, "app.py"), []byte(minimalWSGIApp), 0644)
 
-	_, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "/nonexistent/python-not-found", "")
+	_, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "/nonexistent/python-not-found", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when python path is invalid")
 	}
@@ -1609,7 +1609,7 @@ func TestPythonWorkerCleanup_Timeout(t *testing.T) {
 	tempDir := t.TempDir()
 	os.WriteFile(filepath.Join(tempDir, "app.py"), []byte(minimalWSGIAppIgnoringSIGTERM), 0644)
 
-	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3", "")
+	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3", "", nil, nil)
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup: %v", err)
 	}
@@ -1883,8 +1883,8 @@ func TestPythonDirectiveCaddyfileRouteOrder(t *testing.T) {
 }
 
 func TestDynamicAppResolveWithNilReplacer(t *testing.T) {
-	d, _ := NewDynamicApp("main:app", "/home/static", "",
-		func(module, dir, venv string) (AppServer, error) {
+	d, _ := NewDynamicApp("main:app", "/home/static", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 			return nil, nil
 		},
 		zap.NewNop(),
@@ -1896,7 +1896,7 @@ func TestDynamicAppResolveWithNilReplacer(t *testing.T) {
 	r := &http.Request{}
 	r = r.WithContext(ctx)
 
-	_, module, dir, _ := d.resolve(r)
+	_, module, dir, _, _, _ := d.resolve(r)
 	if module != "main:app" {
 		t.Errorf("expected 'main:app', got %q", module)
 	}
@@ -1944,7 +1944,7 @@ func TestPythonWorkerGroup_LoadsAndServesWSGI(t *testing.T) {
 		t.Fatalf("failed to write app.py: %v", err)
 	}
 
-	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3", "")
+	wg, err := NewPythonWorkerGroup("wsgi", "app:app", tempDir, "", "", "sync", 1, "python3", "", nil, nil)
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
 	}
@@ -1996,7 +1996,7 @@ func TestPythonWorkerGroup_LoadsAndServesASGI(t *testing.T) {
 		t.Fatalf("failed to write app.py: %v", err)
 	}
 
-	wg, err := NewPythonWorkerGroup("asgi", "app:app", tempDir, "", "", "uvloop", 1, "python3", "")
+	wg, err := NewPythonWorkerGroup("asgi", "app:app", tempDir, "", "", "uvloop", 1, "python3", "", nil, nil)
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
 	}
@@ -2055,7 +2055,7 @@ func TestPythonWorkerGroup_LoadsAndServesESGI(t *testing.T) {
 		t.Fatalf("failed to write app.py: %v", err)
 	}
 
-	wg, err := NewPythonWorkerGroup("esgi", "app:application", tempDir, "", "", "gevent", 1, "python3", "")
+	wg, err := NewPythonWorkerGroup("esgi", "app:application", tempDir, "", "", "gevent", 1, "python3", "", nil, nil)
 	if err != nil {
 		t.Fatalf("NewPythonWorkerGroup failed: %v", err)
 	}

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -81,8 +81,8 @@ Dynamic module loading allows a single Caddy configuration to serve multiple dif
 
 The `DynamicApp` struct manages a cache of Python app instances keyed by their resolved configuration:
 
-1. **Placeholder resolution** — on each request, Caddy placeholders in `module_wsgi`/`module_asgi`, `working_dir`, and `venv` are resolved using the request context (e.g. hostname, path, headers)
-2. **Cache lookup** — a composite key (`module|dir|venv`) is used to look up an existing app
+1. **Placeholder resolution** — on each request, Caddy placeholders in `module_wsgi`/`module_asgi`, `working_dir`, `venv`, `env_file`, and `env_var` values are resolved using the request context (e.g. hostname, path, headers)
+2. **Cache lookup** — a composite key (`module|dir|venv|envFiles|envVars`) is used to look up an existing app
 3. **Lazy creation** — if no app exists for the key, one is created via the factory function and cached
 4. **Double-check locking** — a fast-path read lock allows concurrent access, with a write lock only for app creation
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -129,6 +129,45 @@ curl -X POST http://localhost:9080/items \
 
 ---
 
+## Per-app environment variables
+
+Load configuration from a dotenv file and override individual keys inline. Each `python` block gets its own worker environment.
+
+```caddyfile
+route /shop/* {
+    python {
+        module_asgi "shop:app"
+        working_dir "/apps/shop"
+        env_file "/apps/shop/.env"
+        env_var APP_NAME "shop"
+    }
+}
+
+route /blog/* {
+    python {
+        module_wsgi "blog:app"
+        working_dir "/apps/blog"
+        env_file "/apps/blog/.env"
+        env_var APP_NAME "blog"
+    }
+}
+```
+
+For multi-tenant dynamic apps, use placeholders in `env_var` values and place `.env` in each tenant directory:
+
+```caddyfile
+*.example.com:9080 {
+    python /* {
+        module_asgi "{http.request.host.labels.2}:app"
+        working_dir "{http.request.host.labels.2}/"
+        env_file ".env"
+        env_var TENANT "{http.request.host.labels.2}"
+    }
+}
+```
+
+---
+
 ## Django (WSGI)
 
 Django is a full-featured web framework with a built-in admin interface and ORM.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -233,6 +233,23 @@ The venv packages are added to the global `sys.path`, which means all Python app
 
 ---
 
+## Per-app environment variables
+
+Use `env_file` and `env_var` inside a `python` block to configure worker environment variables without setting them globally on the Caddy process. Inline `env_var` entries override values from `env_file` when both set the same name.
+
+```Caddyfile
+python {
+    module_wsgi "main:app"
+    working_dir "/var/www/myapp"
+    env_file "/var/www/myapp/.env"
+    env_var DEBUG "1"
+}
+```
+
+See the [configuration reference](reference#env_file) for precedence, dynamic placeholders, and reserved variable names.
+
+---
+
 ## Platform support
 
 | Platform       | Notes                    |

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -65,6 +65,8 @@ python {
     lifespan on|off
     working_dir <path>
     venv <path>
+    env_file <path>
+    env_var <name> <value>
     workers <count>
     autoreload
 }
@@ -159,6 +161,49 @@ When using `autoreload`, the working directory is also the root directory watche
 
 The `working_dir` directive also supports [Caddy placeholders](#dynamic-module-loading) for dynamic resolution at request time.
 
+### `env_file`
+
+Path to a dotenv-style file (for example `.env`) loaded into the Python worker environment for this `python` block. Repeat the directive to load multiple files; later files override earlier ones for duplicate keys.
+
+Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory.
+
+```caddyfile
+python {
+    module_wsgi "main:app"
+    working_dir "/var/www/myapp"
+    env_file "/var/www/myapp/.env"
+}
+```
+
+Supported file format:
+
+- `KEY=VALUE` lines
+- Optional double or single quotes around values
+- `#` comments and blank lines
+- Optional `export KEY=VALUE` prefix
+
+Changes to env files are picked up when workers are restarted or when [autoreload](#autoreload) respawns workers; env files are not watched independently.
+
+### `env_var`
+
+Set an individual environment variable for workers in this `python` block. Specify exactly two arguments: the variable name and value. Repeat to set multiple variables; later lines override earlier ones for the same name.
+
+**`env_var` is applied after `env_file`**, so inline values override file values when both define the same key.
+
+```caddyfile
+python {
+    module_asgi "main:app"
+    working_dir "/var/www/myapp"
+    env_file "/var/www/myapp/.env"
+    env_var DEBUG "1"
+    env_var DATABASE_URL "postgres://localhost/dev"
+}
+```
+
+Variable names must match `[A-Za-z_][A-Za-z0-9_]*`. Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) cannot be set from the Caddyfile.
+
+**Environment precedence:** Caddy process env → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`).
+
 ### `venv`
 
 Path to a Python virtual environment. Behind the scenes, this appends `venv/lib/python3.x/site-packages` to `sys.path` so installed packages are available to your app.
@@ -209,7 +254,7 @@ python {
 
 ## Dynamic Module Loading
 
-You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, and `venv` to dynamically load different Python apps based on the request.
+You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, `venv`, `env_file`, and `env_var` values to dynamically load different Python apps based on the request.
 
 This is useful for multi-tenant setups where each subdomain or route serves a different application.
 
@@ -229,10 +274,10 @@ In this example:
 
 ### How it works
 
-When any of the configuration values (`module_wsgi`/`module_asgi`, `working_dir`, `venv`) contain Caddy placeholders (e.g. `{http.request.host.labels.2}`), Caddy Snake creates a **DynamicApp** that:
+When any of the configuration values (`module_wsgi`/`module_asgi`, `working_dir`, `venv`, `env_file`, or `env_var` values) contain Caddy placeholders (e.g. `{http.request.host.labels.2}`), Caddy Snake creates a **DynamicApp** that:
 
 1. Resolves the placeholders at request time using the Caddy replacer
-2. Builds a composite cache key from the resolved module, directory, and venv
+2. Builds a composite cache key from the resolved module, directory, venv, env files, and inline env vars
 3. Returns an existing app if one is cached for that key
 4. Otherwise, lazily imports the Python module and creates a new app instance
 5. Uses double-check locking for thread-safe concurrent access

--- a/dynamic.go
+++ b/dynamic.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -62,9 +63,54 @@ func containsPlaceholder(s string) bool {
 	return strings.Contains(s, "{") && strings.Contains(s, "}")
 }
 
+func validateResolvedEnvConfig(dir string, envFiles []string) error {
+	for _, p := range envFiles {
+		if p == "" {
+			continue
+		}
+		if containsPlaceholder(p) {
+			return fmt.Errorf("env_file path contains unresolved placeholder: %q", p)
+		}
+		if hasDotDotSegment(p) {
+			return fmt.Errorf("env_file path contains path traversal: %q", p)
+		}
+		abs, err := resolveEnvFilePath(dir, p)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return fmt.Errorf("env_file %q: %w", abs, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("env_file %q is a directory", abs)
+		}
+	}
+	return nil
+}
+
+func envVarsCacheKey(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(m[k])
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
 // appFactory is a function that creates a new AppServer for a resolved
-// module, working directory and venv path combination.
-type appFactory func(resolvedModule, resolvedDir, resolvedVenv string) (AppServer, error)
+// module, working directory, venv path, and env configuration.
+type appFactory func(resolvedModule, resolvedDir, resolvedVenv string, envFiles []string, envVars map[string]string) (AppServer, error)
 
 // DynamicApp implements AppServer by lazily importing Python apps based on
 // Caddy placeholders resolved at request time. For example, when working_dir
@@ -73,10 +119,12 @@ type appFactory func(resolvedModule, resolvedDir, resolvedVenv string) (AppServe
 type DynamicApp struct {
 	mu            sync.RWMutex
 	apps          map[string]AppServer
-	modulePattern string
-	workingDir    string
-	venvPath      string
-	factory       appFactory
+	modulePattern   string
+	workingDir      string
+	venvPath        string
+	envFilePatterns []string
+	envVarPatterns  map[string]string
+	factory         appFactory
 	logger        *zap.Logger
 
 	// Autoreload fields
@@ -88,16 +136,18 @@ type DynamicApp struct {
 }
 
 // NewDynamicApp creates a DynamicApp that resolves placeholders from
-// modulePattern, workingDir, and venvPath at request time and lazily creates
-// Python app instances via the supplied factory function.
+// modulePattern, workingDir, venvPath, env_file paths, and env_var values at
+// request time and lazily creates Python app instances via the supplied factory.
 // When autoreload is true, if exitOnReloadFailure is non-nil it is called with
 // code 1 when app creation fails (e.g. app deleted), so the process can terminate.
-func NewDynamicApp(modulePattern, workingDir, venvPath string, factory appFactory, logger *zap.Logger, autoreload bool, exitOnReloadFailure func(code int)) (*DynamicApp, error) {
+func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns []string, envVarPatterns map[string]string, factory appFactory, logger *zap.Logger, autoreload bool, exitOnReloadFailure func(code int)) (*DynamicApp, error) {
 	d := &DynamicApp{
 		apps:                 make(map[string]AppServer),
 		modulePattern:        modulePattern,
 		workingDir:           workingDir,
 		venvPath:             venvPath,
+		envFilePatterns:      cloneEnvFiles(envFilePatterns),
+		envVarPatterns:       cloneEnvVars(envVarPatterns),
 		factory:              factory,
 		logger:               logger,
 		autoreload:           autoreload,
@@ -120,27 +170,44 @@ func NewDynamicApp(modulePattern, workingDir, venvPath string, factory appFactor
 }
 
 // resolve uses the Caddy replacer from the request context to substitute
-// placeholders in the module pattern, working directory, and venv path.
-func (d *DynamicApp) resolve(r *http.Request) (key, module, dir, venv string) {
+// placeholders in the module pattern, working directory, venv path, env files,
+// and env_var values.
+func (d *DynamicApp) resolve(r *http.Request) (key, module, dir, venv string, envFiles []string, envVars map[string]string) {
 	module = d.modulePattern
 	dir = d.workingDir
 	venv = d.venvPath
+	envFiles = cloneEnvFiles(d.envFilePatterns)
+	envVars = cloneEnvVars(d.envVarPatterns)
 
 	if repl, ok := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer); ok && repl != nil {
 		module = repl.ReplaceAll(module, "")
 		dir = repl.ReplaceAll(dir, "")
 		venv = repl.ReplaceAll(venv, "")
+		for i, p := range envFiles {
+			envFiles[i] = repl.ReplaceAll(p, "")
+		}
+		for name, value := range envVars {
+			envVars[name] = repl.ReplaceAll(value, "")
+		}
 	}
 
-	key = module + "|" + dir + "|" + venv
+	key = module + "|" + dir + "|" + venv + "|" + strings.Join(envFiles, ",") + "|" + envVarsCacheKey(envVars)
 	return
 }
 
 // getOrCreateApp returns an existing app for the given key, or creates one
 // using the factory if it doesn't exist yet.
-func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string) (AppServer, error) {
+func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
 	if err := validateResolvedValues(module, dir, venv); err != nil {
 		return nil, err
+	}
+	if err := validateResolvedEnvConfig(dir, envFiles); err != nil {
+		return nil, err
+	}
+	for name, value := range envVars {
+		if containsPlaceholder(value) {
+			return nil, fmt.Errorf("env_var %q contains unresolved placeholder", name)
+		}
 	}
 
 	d.mu.RLock()
@@ -164,7 +231,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string) (AppServer, e
 		zap.String("venv", venv),
 	)
 
-	app, err := d.factory(module, dir, venv)
+	app, err := d.factory(module, dir, venv, cloneEnvFiles(envFiles), cloneEnvVars(envVars))
 	if err != nil {
 		return nil, err
 	}
@@ -315,8 +382,8 @@ func (d *DynamicApp) reloadDir(absDir string) {
 // HandleRequest resolves placeholders from the request, gets or creates the
 // appropriate app, and forwards the request.
 func (d *DynamicApp) HandleRequest(w http.ResponseWriter, r *http.Request) error {
-	key, module, dir, venv := d.resolve(r)
-	app, err := d.getOrCreateApp(key, module, dir, venv)
+	key, module, dir, venv, envFiles, envVars := d.resolve(r)
+	app, err := d.getOrCreateApp(key, module, dir, venv, envFiles, envVars)
 	if err != nil {
 		if d.autoreload && d.exitOnReloadFailure != nil {
 			d.logger.Error("failed to load python app (autoreload); terminating",

--- a/env_file.go
+++ b/env_file.go
@@ -1,0 +1,222 @@
+package caddysnake
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var validEnvVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func validateEnvVarName(name string) error {
+	if !validEnvVarName.MatchString(name) {
+		return fmt.Errorf("must match [A-Za-z_][A-Za-z0-9_]*")
+	}
+	if name == "PYTHONUNBUFFERED" || strings.HasPrefix(name, "CADDYSNAKE_") {
+		return fmt.Errorf("reserved environment variable name")
+	}
+	return nil
+}
+
+func validateEnvVars(envVars map[string]string) error {
+	for name := range envVars {
+		if err := validateEnvVarName(name); err != nil {
+			return fmt.Errorf("invalid env_var name %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func envMapContainsPlaceholder(envVars map[string]string) bool {
+	for _, v := range envVars {
+		if containsPlaceholder(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func envFilesContainPlaceholder(paths []string) bool {
+	for _, p := range paths {
+		if containsPlaceholder(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneEnvVars(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneEnvFiles(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]string, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func resolveEnvFilePath(workingDir, envFile string) (string, error) {
+	if envFile == "" {
+		return "", fmt.Errorf("env_file path is empty")
+	}
+	if hasDotDotSegment(envFile) {
+		return "", fmt.Errorf("env_file path contains path traversal: %q", envFile)
+	}
+	path := envFile
+	if !filepath.IsAbs(path) {
+		base := workingDir
+		if base == "" {
+			var err error
+			base, err = os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("resolve env_file base directory: %w", err)
+			}
+		}
+		path = filepath.Join(base, path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid env_file path: %w", err)
+	}
+	return abs, nil
+}
+
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	vars := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for lineNum := 1; scanner.Scan(); lineNum++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("%s:%d: invalid line (expected KEY=VALUE)", path, lineNum)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("%s:%d: empty variable name", path, lineNum)
+		}
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		vars[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return vars, nil
+}
+
+func loadEnvFiles(workingDir string, paths []string) (map[string]string, error) {
+	merged := make(map[string]string)
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if containsPlaceholder(p) {
+			return nil, fmt.Errorf("env_file path contains unresolved placeholder: %q", p)
+		}
+		abs, err := resolveEnvFilePath(workingDir, p)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, fmt.Errorf("env_file %q: %w", abs, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("env_file %q is a directory", abs)
+		}
+		vars, err := parseEnvFile(abs)
+		if err != nil {
+			return nil, fmt.Errorf("env_file %q: %w", abs, err)
+		}
+		for k, v := range vars {
+			merged[k] = v
+		}
+	}
+	return merged, nil
+}
+
+func parseEnvSlice(base []string) map[string]string {
+	m := make(map[string]string, len(base))
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if idx := strings.Index(key, "\x00"); idx >= 0 {
+			key = key[:idx]
+		}
+		m[key] = value
+	}
+	return m
+}
+
+func envMapToSlice(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// buildWorkerEnv merges environment variables with precedence:
+// base (process env) < fileVars < inlineVars < extra (internal vars).
+func buildWorkerEnv(base []string, fileVars, inlineVars map[string]string, extra ...string) []string {
+	merged := parseEnvSlice(base)
+	for k, v := range fileVars {
+		merged[k] = v
+	}
+	for k, v := range inlineVars {
+		merged[k] = v
+	}
+	for _, entry := range extra {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		merged[key] = value
+	}
+	return envMapToSlice(merged)
+}
+
+func workerInternalEnv(iface, cacheAddr string) []string {
+	extra := []string{"PYTHONUNBUFFERED=1"}
+	if cacheAddr != "" {
+		extra = append(extra,
+			EnvCaddysnakeCacheAddr+"="+cacheAddr,
+			EnvCaddysnakeWorkerInterface+"="+iface,
+			EnvCaddysnakeCacheTimeoutSeconds+"="+strconv.Itoa(DefaultCacheClientTimeoutSec),
+		)
+	}
+	return extra
+}

--- a/env_file_test.go
+++ b/env_file_test.go
@@ -1,0 +1,203 @@
+package caddysnake
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestParseEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := `# comment
+export APP_TEST_FROM_FILE=file_value
+APP_TEST_QUOTED="hello world"
+APP_TEST_SINGLE='single'
+
+APP_TEST_OVERRIDE=from_file
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	vars, err := parseEnvFile(path)
+	if err != nil {
+		t.Fatalf("parseEnvFile: %v", err)
+	}
+	if vars["APP_TEST_FROM_FILE"] != "file_value" {
+		t.Errorf("APP_TEST_FROM_FILE = %q", vars["APP_TEST_FROM_FILE"])
+	}
+	if vars["APP_TEST_QUOTED"] != "hello world" {
+		t.Errorf("APP_TEST_QUOTED = %q", vars["APP_TEST_QUOTED"])
+	}
+	if vars["APP_TEST_SINGLE"] != "single" {
+		t.Errorf("APP_TEST_SINGLE = %q", vars["APP_TEST_SINGLE"])
+	}
+	if vars["APP_TEST_OVERRIDE"] != "from_file" {
+		t.Errorf("APP_TEST_OVERRIDE = %q", vars["APP_TEST_OVERRIDE"])
+	}
+}
+
+func TestParseEnvFile_InvalidLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte("NOT_VALID\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := parseEnvFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid line")
+	}
+}
+
+func TestBuildWorkerEnv_Precedence(t *testing.T) {
+	base := []string{"SHARED=from_process", "ONLY_BASE=1"}
+	fileVars := map[string]string{
+		"SHARED":          "from_file",
+		"APP_TEST_FROM_FILE": "file_value",
+	}
+	inlineVars := map[string]string{
+		"SHARED":             "from_inline",
+		"APP_TEST_INLINE":    "inline_value",
+		"APP_TEST_OVERRIDE":  "from_inline",
+	}
+	extra := []string{"PYTHONUNBUFFERED=1", "CADDYSNAKE_CACHE_ADDR=unix://test"}
+
+	env := buildWorkerEnv(base, fileVars, inlineVars, extra...)
+	m := parseEnvSlice(env)
+
+	if m["SHARED"] != "from_inline" {
+		t.Errorf("SHARED = %q, want from_inline", m["SHARED"])
+	}
+	if m["APP_TEST_FROM_FILE"] != "file_value" {
+		t.Errorf("APP_TEST_FROM_FILE = %q", m["APP_TEST_FROM_FILE"])
+	}
+	if m["APP_TEST_INLINE"] != "inline_value" {
+		t.Errorf("APP_TEST_INLINE = %q", m["APP_TEST_INLINE"])
+	}
+	if m["ONLY_BASE"] != "1" {
+		t.Errorf("ONLY_BASE = %q", m["ONLY_BASE"])
+	}
+	if m["PYTHONUNBUFFERED"] != "1" {
+		t.Errorf("PYTHONUNBUFFERED = %q", m["PYTHONUNBUFFERED"])
+	}
+	if m["CADDYSNAKE_CACHE_ADDR"] != "unix://test" {
+		t.Errorf("CADDYSNAKE_CACHE_ADDR = %q", m["CADDYSNAKE_CACHE_ADDR"])
+	}
+}
+
+func TestResolveEnvFilePath(t *testing.T) {
+	dir := t.TempDir()
+	rel := filepath.Join("configs", "app.env")
+	abs, err := resolveEnvFilePath(dir, rel)
+	if err != nil {
+		t.Fatalf("resolveEnvFilePath: %v", err)
+	}
+	want := filepath.Join(dir, rel)
+	wantAbs, _ := filepath.Abs(want)
+	if abs != wantAbs {
+		t.Errorf("got %q, want %q", abs, wantAbs)
+	}
+
+	_, err = resolveEnvFilePath(dir, "../escape.env")
+	if err == nil {
+		t.Fatal("expected traversal error")
+	}
+}
+
+func TestLoadEnvFiles_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.env")
+	second := filepath.Join(dir, "second.env")
+	if err := os.WriteFile(first, []byte("A=1\nB=from_first\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("B=from_second\nC=3\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	vars, err := loadEnvFiles(dir, []string{first, second})
+	if err != nil {
+		t.Fatalf("loadEnvFiles: %v", err)
+	}
+	if vars["A"] != "1" || vars["B"] != "from_second" || vars["C"] != "3" {
+		t.Errorf("vars = %#v", vars)
+	}
+}
+
+func TestValidateEnvVarName(t *testing.T) {
+	if err := validateEnvVarName("APP_TEST_OK"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateEnvVarName("1BAD"); err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if err := validateEnvVarName("CADDYSNAKE_CACHE_ADDR"); err == nil {
+		t.Error("expected error for reserved name")
+	}
+	if err := validateEnvVarName("PYTHONUNBUFFERED"); err == nil {
+		t.Error("expected error for reserved name")
+	}
+}
+
+func TestUnmarshalCaddyfile_EnvFile(t *testing.T) {
+	input := `python {
+		module_wsgi main:app
+		env_file /tmp/a.env
+		env_file ./b.env
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	var cs CaddySnake
+	if err := cs.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cs.EnvFiles) != 2 || cs.EnvFiles[0] != "/tmp/a.env" || cs.EnvFiles[1] != "./b.env" {
+		t.Errorf("EnvFiles = %#v", cs.EnvFiles)
+	}
+}
+
+func TestUnmarshalCaddyfile_EnvVar(t *testing.T) {
+	input := `python {
+		module_asgi main:app
+		env_var APP_TEST_INLINE inline_value
+		env_var APP_TEST_OVERRIDE override_value
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	var cs CaddySnake
+	if err := cs.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cs.EnvVars["APP_TEST_INLINE"] != "inline_value" {
+		t.Errorf("APP_TEST_INLINE = %q", cs.EnvVars["APP_TEST_INLINE"])
+	}
+	if cs.EnvVars["APP_TEST_OVERRIDE"] != "override_value" {
+		t.Errorf("APP_TEST_OVERRIDE = %q", cs.EnvVars["APP_TEST_OVERRIDE"])
+	}
+}
+
+func TestUnmarshalCaddyfile_EnvVarReserved(t *testing.T) {
+	input := `python {
+		module_wsgi main:app
+		env_var CADDYSNAKE_CACHE_ADDR evil
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	var cs CaddySnake
+	err := cs.UnmarshalCaddyfile(d)
+	if err == nil || !strings.Contains(err.Error(), "invalid env_var name") {
+		t.Fatalf("expected reserved name error, got %v", err)
+	}
+}
+
+func TestValidate_EnvVarReserved(t *testing.T) {
+	cs := CaddySnake{
+		ModuleWsgi: "main:app",
+		EnvVars:    map[string]string{"PYTHONUNBUFFERED": "0"},
+	}
+	err := cs.Validate()
+	if err == nil || !strings.Contains(err.Error(), "PYTHONUNBUFFERED") {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}

--- a/tests/dynamic/Caddyfile
+++ b/tests/dynamic/Caddyfile
@@ -9,6 +9,9 @@
 	python /* {
 		module_asgi "{http.request.host.labels.6}:app"
 		working_dir "{http.request.host.labels.6}/"
+		env_file ".env"
+		env_var APP_TEST_INLINE "{http.request.host.labels.6}_inline"
+		env_var APP_TEST_OVERRIDE "override_{http.request.host.labels.6}"
 		workers 1
 	}
 }

--- a/tests/dynamic/app1/.env
+++ b/tests/dynamic/app1/.env
@@ -1,0 +1,2 @@
+APP_TEST_FROM_FILE=app1_file
+APP_TEST_OVERRIDE=app1_from_file

--- a/tests/dynamic/app1/app1.py
+++ b/tests/dynamic/app1/app1.py
@@ -1,6 +1,20 @@
+import os
+
+ALLOWED_ENV_VARS = frozenset(
+    {
+        "APP_TEST_FROM_FILE",
+        "APP_TEST_INLINE",
+        "APP_TEST_OVERRIDE",
+    }
+)
+
+
 async def app(scope, receive, send):
-    """Simple ASGI app that identifies itself as app1."""
-    if scope["type"] == "http":
+    if scope["type"] != "http":
+        return
+
+    path = scope["path"]
+    if path == "/hello":
         await send(
             {
                 "type": "http.response.start",
@@ -9,3 +23,47 @@ async def app(scope, receive, send):
             }
         )
         await send({"type": "http.response.body", "body": b"Hello from app1"})
+        return
+
+    if path.startswith("/env/"):
+        name = path[5:]
+        if name not in ALLOWED_ENV_VARS:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"not found"})
+            return
+        value = os.environ.get(name)
+        if value is None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"unset"})
+            return
+        body = value.encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+        return
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 404,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Not Found"})

--- a/tests/dynamic/app2/.env
+++ b/tests/dynamic/app2/.env
@@ -1,0 +1,2 @@
+APP_TEST_FROM_FILE=app2_file
+APP_TEST_OVERRIDE=app2_from_file

--- a/tests/dynamic/app2/app2.py
+++ b/tests/dynamic/app2/app2.py
@@ -1,6 +1,20 @@
+import os
+
+ALLOWED_ENV_VARS = frozenset(
+    {
+        "APP_TEST_FROM_FILE",
+        "APP_TEST_INLINE",
+        "APP_TEST_OVERRIDE",
+    }
+)
+
+
 async def app(scope, receive, send):
-    """Simple ASGI app that identifies itself as app2."""
-    if scope["type"] == "http":
+    if scope["type"] != "http":
+        return
+
+    path = scope["path"]
+    if path == "/hello":
         await send(
             {
                 "type": "http.response.start",
@@ -9,3 +23,47 @@ async def app(scope, receive, send):
             }
         )
         await send({"type": "http.response.body", "body": b"Hello from app2"})
+        return
+
+    if path.startswith("/env/"):
+        name = path[5:]
+        if name not in ALLOWED_ENV_VARS:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"not found"})
+            return
+        value = os.environ.get(name)
+        if value is None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"unset"})
+            return
+        body = value.encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+        return
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 404,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Not Found"})

--- a/tests/dynamic/app3/.env
+++ b/tests/dynamic/app3/.env
@@ -1,0 +1,2 @@
+APP_TEST_FROM_FILE=app3_file
+APP_TEST_OVERRIDE=app3_from_file

--- a/tests/dynamic/app3/app3.py
+++ b/tests/dynamic/app3/app3.py
@@ -1,6 +1,20 @@
+import os
+
+ALLOWED_ENV_VARS = frozenset(
+    {
+        "APP_TEST_FROM_FILE",
+        "APP_TEST_INLINE",
+        "APP_TEST_OVERRIDE",
+    }
+)
+
+
 async def app(scope, receive, send):
-    """Simple ASGI app that identifies itself as app3."""
-    if scope["type"] == "http":
+    if scope["type"] != "http":
+        return
+
+    path = scope["path"]
+    if path == "/hello":
         await send(
             {
                 "type": "http.response.start",
@@ -9,3 +23,47 @@ async def app(scope, receive, send):
             }
         )
         await send({"type": "http.response.body", "body": b"Hello from app3"})
+        return
+
+    if path.startswith("/env/"):
+        name = path[5:]
+        if name not in ALLOWED_ENV_VARS:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"not found"})
+            return
+        value = os.environ.get(name)
+        if value is None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 404,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"unset"})
+            return
+        body = value.encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+        return
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 404,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Not Found"})

--- a/tests/dynamic/main_test.py
+++ b/tests/dynamic/main_test.py
@@ -18,6 +18,24 @@ APPS = {
     "app3": "Hello from app3",
 }
 
+ENV_EXPECTATIONS = {
+    "app1": {
+        "APP_TEST_FROM_FILE": "app1_file",
+        "APP_TEST_INLINE": "app1_inline",
+        "APP_TEST_OVERRIDE": "override_app1",
+    },
+    "app2": {
+        "APP_TEST_FROM_FILE": "app2_file",
+        "APP_TEST_INLINE": "app2_inline",
+        "APP_TEST_OVERRIDE": "override_app2",
+    },
+    "app3": {
+        "APP_TEST_FROM_FILE": "app3_file",
+        "APP_TEST_INLINE": "app3_inline",
+        "APP_TEST_OVERRIDE": "override_app3",
+    },
+}
+
 
 def wait_for_all_apps_healthy(
     timeout_seconds: float = 90.0, interval: float = 0.5
@@ -48,6 +66,11 @@ def request_app(name: str) -> requests.Response:
     """Send a GET request to the given app subdomain via Host header."""
     host = f"{name}.127.0.0.1.nip.io"
     return requests.get(f"{BASE_URL}/hello", headers={"Host": host})
+
+
+def request_app_env(name: str, var: str) -> requests.Response:
+    host = f"{name}.127.0.0.1.nip.io"
+    return requests.get(f"{BASE_URL}/env/{var}", headers={"Host": host})
 
 
 def test_individual_apps():
@@ -101,6 +124,25 @@ def test_concurrent_requests():
     print(f"  OK  {len(APPS) * 30} concurrent requests passed")
 
 
+def test_env_file_and_env_var():
+    """Verify env_file and env_var are applied per dynamic app instance."""
+    for app_name, expected in ENV_EXPECTATIONS.items():
+        for var, want in expected.items():
+            resp = request_app_env(app_name, var)
+            assert resp.status_code == 200, (
+                f"[{app_name}] GET /env/{var} status={resp.status_code} body={resp.text!r}"
+            )
+            assert resp.text == want, (
+                f"[{app_name}] /env/{var} expected {want!r}, got {resp.text!r}"
+            )
+            print(f"  OK  {app_name} {var}={resp.text!r}")
+
+        unknown = request_app_env(app_name, "UNKNOWN")
+        assert unknown.status_code == 404, (
+            f"[{app_name}] expected 404 for unknown env var, got {unknown.status_code}"
+        )
+
+
 if __name__ == "__main__":
     start = time.time()
 
@@ -115,6 +157,9 @@ if __name__ == "__main__":
 
     print(">>> Testing concurrent requests...")
     test_concurrent_requests()
+
+    print(">>> Testing env_file and env_var...")
+    test_env_file_and_env_var()
 
     elapsed = time.time() - start
     print(f"\nAll dynamic module tests passed! ({elapsed:.2f}s)")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two new `python` block subdirectives for per-block worker environment configuration:

- **`env_file <path>`** — load variables from a dotenv-style file (repeatable; later files override earlier keys)
- **`env_var VARNAME value`** — set inline variables after file loading (overrides file values for the same key)

Environment merge order: Caddy process env → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`).

## Implementation

- New [`env_file.go`](env_file.go) with dotenv parsing, path resolution (relative to `working_dir`), and env merging
- Worker spawn path updated in `PythonWorker.Start()` via `buildWorkerEnv`
- Dynamic mode resolves placeholders in `env_file` paths and `env_var` values; cache key includes resolved env config
- Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) rejected at parse/validate time

## Tests

- Unit tests in [`env_file_test.go`](env_file_test.go) for parsing, precedence, path resolution, and Caddyfile unmarshaling
- Extended [`tests/dynamic`](tests/dynamic) integration test with per-app `.env` files, placeholder `env_var`, and HTTP `/env/<name>` checks

## Documentation

Updated README and docs (`reference.md`, `architecture.md`, `examples.md`, `intro.md`).

## Example

```caddyfile
python {
    module_asgi "main:app"
    working_dir "/apps/shop"
    env_file "/apps/shop/.env"
    env_var DEBUG "1"
}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d8ace3e-03c6-45da-a177-63afbcb40b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d8ace3e-03c6-45da-a177-63afbcb40b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

