### PR TITLE
Add worker cache sync: sets, pub/sub, SETNX, keys, worker ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,26 @@ Or run checks individually:
 6. **Integration tests** — at minimum **Flask** and **FastAPI**:
    - `./tests/integration.sh flask 3.13`
    - `./tests/integration.sh fastapi 3.13`
+   - For **shared cache** changes: `./tests/integration.sh simple_cache 3.13`
 7. **Embed-app** (optional, requires network): `cd cmd/embed-app && ./build.sh app.zip 3.13 && ./test_embed.sh embed-test`
 
 Install hook once: `pre-commit install`
 
 See [Running tests](#running-tests) and [Automated quality assurance](#automated-quality-assurance) for details.
+
+---
+
+## Documentation
+
+When you implement or change a **user-facing feature** (Caddyfile directives, worker env vars, Python/Go APIs, cache protocol, CLI behavior, integration-test apps, etc.), **update the docs in the same PR** before merge:
+
+1. **[`docs/docs/reference.md`](docs/docs/reference.md)** — authoritative configuration and API reference (Read the Docs).
+2. **[`README.md`](README.md)** — overview and quick examples for GitHub visitors.
+3. **[`AGENTS.md`](AGENTS.md)** — only when agent/workflow guidance changes (setup, QA, release steps).
+
+For cache or multi-worker features, also cover: env vars, wire protocol (`CS*` commands if applicable), Python API, limits, security/trust model, and an integration test under `tests/` when behavior spans workers.
+
+Build docs locally if you touch MkDocs content: `cd docs && mkdocs build` (also exercised in CI **Lint**).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -361,18 +361,24 @@ Process-based workers run in **separate Python interpreters**, so they do not sh
 - **Linux and macOS:** the plugin listens on a **Unix domain socket** under a private temporary directory and sets **`CADDYSNAKE_CACHE_ADDR`** to a **`unix:///absolute/path/to/cache.sock`** URL. Traffic stays on the filesystem socket, not the generic TCP/IP stack.
 - **Windows:** workers use **loopback TCP**; **`CADDYSNAKE_CACHE_ADDR`** is like **`127.0.0.1:<ephemeral-port>`**.
 
-Caddy also sets **`CADDYSNAKE_WORKER_INTERFACE`** (`wsgi`, `asgi`, `esgi`, …) and **`CADDYSNAKE_CACHE_TIMEOUT`** (read/connect hint in seconds) for the Python client.
+Caddy also sets **`CADDYSNAKE_WORKER_INTERFACE`** (`wsgi`, `asgi`, `esgi`, …), **`CADDYSNAKE_WORKER_ID`** (stable index `0`…`N-1` per worker group), and **`CADDYSNAKE_CACHE_TIMEOUT`** (read/connect hint in seconds) for the Python client.
+
+The cache supports **scalars**, **FIFO lists**, **sets** (`sadd`/`srem`/`smembers`), atomic **`setnx`**, prefix **`keys`**, and one-shot **`publish`/`subscribe`** for cross-worker coordination.
 
 From app code (with the **`caddysnake`** PyPI package / CLI wheel installed in your venv), use the façade described in the [configuration reference](https://caddy-snake.readthedocs.io/en/latest/docs/reference/#shared-worker-cache):
 
 ```python
-from caddysnake import cache
+from caddysnake import cache, worker_id
 
-cache.set("visits", b"1")
-cache.append("log", b"line\n")
+cache.set("myapp:visits", b"1")
+cache.append("myapp:log", b"line\n")
+cache.sadd("myapp:group", f"worker:{worker_id()}".encode())
+if cache.setnx("myapp:lock", b"1", ttl=30):
+    ...
+msg = cache.subscribe("myapp:events", timeout=10.0)  # one-shot blocking receive
 ```
 
-Thread workers and single-worker setups do not need this path. See the docs for semantics, limits, and when to prefer Redis or another external store.
+Thread workers and single-worker setups do not need this path. See the [configuration reference](https://caddy-snake.readthedocs.io/en/latest/docs/reference/#shared-worker-cache) for the full API (sets, `setnx`, prefix `keys`, `publish`/`subscribe`, limits, and security notes).
 
 ---
 

--- a/cache_server.go
+++ b/cache_server.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,6 +21,7 @@ import (
 const (
 	EnvCaddysnakeCacheAddr           = "CADDYSNAKE_CACHE_ADDR"
 	EnvCaddysnakeWorkerInterface     = "CADDYSNAKE_WORKER_INTERFACE"
+	EnvCaddysnakeWorkerID            = "CADDYSNAKE_WORKER_ID"
 	EnvCaddysnakeCacheTimeoutSeconds = "CADDYSNAKE_CACHE_TIMEOUT"
 )
 
@@ -30,28 +33,36 @@ const cacheAddrUnixScheme = "unix://"
 
 // Resource limits (conservative defaults).
 const (
-	maxCacheKeyLen        = 8192
-	maxCacheScalarLen     = 1 << 20 // 1 MiB
-	maxCacheListElemLen   = 1 << 20
-	maxCacheListLen       = 100_000
-	maxCacheKeys          = 1_000_000
-	maxRESPProtoLineBytes = 1 << 20
+	maxCacheKeyLen         = 8192
+	maxCacheScalarLen      = 1 << 20 // 1 MiB
+	maxCacheListElemLen    = 1 << 20
+	maxCacheListLen        = 100_000
+	maxCacheKeys           = 1_000_000
+	maxRESPProtoLineBytes  = 1 << 20
+	defaultCSKEYSLimit     = 1000
+	maxCSKEYSLimit         = 1000
+	maxSubscribeTimeoutSec = 300.0
 )
 
-var errCacheLimit = errors.New("limit")
+var (
+	errCacheLimit = errors.New("limit")
+	errWrongType  = errors.New("wrong type")
+)
 
 type entryKind int
 
 const (
 	entryScalar entryKind = iota
 	entryList
+	entrySet
 )
 
 type cacheEntry struct {
-	kind   entryKind
-	scalar []byte
-	list   [][]byte
-	expiry *time.Time // wall clock; nil = no expiry
+	kind    entryKind
+	scalar  []byte
+	list    [][]byte
+	members map[string][]byte // set: dedup by string(member bytes)
+	expiry  *time.Time        // wall clock; nil = no expiry
 }
 
 func (e *cacheEntry) expired(now time.Time) bool {
@@ -62,10 +73,11 @@ func (e *cacheEntry) expired(now time.Time) bool {
 }
 
 type cacheStore struct {
-	mu     sync.Mutex
-	data   map[string]*cacheEntry
-	conds  map[string]*sync.Cond // lazily created; all use &mu
-	keyCap int                   //nolint:unused // reserved for future max-keys enforcement
+	mu      sync.Mutex
+	data    map[string]*cacheEntry
+	conds   map[string]*sync.Cond // lazily created; all use &mu
+	closing bool
+	keyCap  int //nolint:unused // reserved for future max-keys enforcement
 }
 
 func newCacheStore() *cacheStore {
@@ -98,6 +110,31 @@ func (s *cacheStore) broadcastKey(key string) {
 func (s *cacheStore) deleteEntryLocked(key string) {
 	delete(s.data, key)
 	s.dropCond(key)
+}
+
+func (s *cacheStore) shutdownLocked() {
+	s.closing = true
+	for _, c := range s.conds {
+		c.Broadcast()
+	}
+}
+
+func (s *cacheStore) Shutdown() {
+	s.mu.Lock()
+	s.shutdownLocked()
+	s.mu.Unlock()
+}
+
+func (s *cacheStore) entryLocked(k string, now time.Time) (*cacheEntry, bool) {
+	e := s.data[k]
+	if e == nil {
+		return nil, false
+	}
+	if e.expired(now) {
+		s.deleteEntryLocked(k)
+		return nil, false
+	}
+	return e, true
 }
 
 func (s *cacheStore) checkKeyLen(key []byte) error {
@@ -172,32 +209,35 @@ func (s *cacheStore) Set(key, value []byte, ttlSec int64) error {
 	return nil
 }
 
-// Get returns (scalar, nil, true, true) | (nil, listCopy, false, true) | (_, _, _, false) miss.
-func (s *cacheStore) Get(key []byte) (scalar []byte, list [][]byte, isList, ok bool) {
+// Get returns value data and kind. ok=false on miss or invalid key.
+func (s *cacheStore) Get(key []byte) (scalar []byte, list [][]byte, setMembers [][]byte, kind entryKind, ok bool) {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := s.checkKeyLen(key); err != nil {
-		return nil, nil, false, false
+		return nil, nil, nil, entryScalar, false
 	}
 	k := string(key)
-	e := s.data[k]
-	if e == nil {
-		return nil, nil, false, false
+	e, ok := s.entryLocked(k, now)
+	if !ok {
+		return nil, nil, nil, entryScalar, false
 	}
-	if e.expired(now) {
-		s.deleteEntryLocked(k)
-		return nil, nil, false, false
+	switch e.kind {
+	case entryScalar:
+		return append([]byte(nil), e.scalar...), nil, nil, entryScalar, true
+	case entryList:
+		out := make([][]byte, len(e.list))
+		for i, b := range e.list {
+			out[i] = append([]byte(nil), b...)
+		}
+		return nil, out, nil, entryList, true
+	case entrySet:
+		out := setMembersSorted(e.members)
+		return nil, nil, out, entrySet, true
+	default:
+		return nil, nil, nil, entryScalar, false
 	}
-	if e.kind == entryScalar {
-		return append([]byte(nil), e.scalar...), nil, false, true
-	}
-	out := make([][]byte, len(e.list))
-	for i, b := range e.list {
-		out[i] = append([]byte(nil), b...)
-	}
-	return nil, out, true, true
 }
 
 func (s *cacheStore) Delete(key []byte) int {
@@ -258,6 +298,9 @@ func (s *cacheStore) Append(key, value []byte) error {
 
 	// clear TTL on append (per spec)
 	noTTL := (*time.Time)(nil)
+	if e.kind == entrySet {
+		return errWrongType
+	}
 	if e.kind == entryScalar {
 		if 2 > maxCacheListLen {
 			return fmt.Errorf("%w: list length", errCacheLimit)
@@ -308,19 +351,23 @@ func (s *cacheStore) Pop(key []byte, deadline *time.Time) ([]byte, bool) {
 	}
 
 	for {
-		now := time.Now()
-		e := s.data[k]
-		if e == nil || e.expired(now) {
-			if e != nil {
-				s.deleteEntryLocked(k)
-			}
+		if s.closing {
 			if timer != nil {
 				timer.Stop()
 			}
 			s.mu.Unlock()
 			return nil, false
 		}
-		if e.kind == entryScalar {
+		now := time.Now()
+		e, exists := s.entryLocked(k, now)
+		if !exists {
+			if timer != nil {
+				timer.Stop()
+			}
+			s.mu.Unlock()
+			return nil, false
+		}
+		if e.kind == entryScalar || e.kind == entrySet {
 			if timer != nil {
 				timer.Stop()
 			}
@@ -349,6 +396,316 @@ func (s *cacheStore) Pop(key []byte, deadline *time.Time) ([]byte, bool) {
 		cond := s.condForKey(k)
 		cond.Wait()
 	}
+}
+
+func setMembersSorted(m map[string][]byte) [][]byte {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	out := make([][]byte, len(keys))
+	for i, k := range keys {
+		out[i] = append([]byte(nil), m[k]...)
+	}
+	return out
+}
+
+func sortStrings(ss []string) {
+	sort.Strings(ss)
+}
+
+// SAdd returns 1 if member was added, 0 if already present.
+func (s *cacheStore) SAdd(key, member []byte) (int, error) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.checkKeyLen(key); err != nil {
+		return 0, err
+	}
+	if err := s.checkElem(member); err != nil {
+		return 0, err
+	}
+	k := string(key)
+	mk := string(member)
+	e := s.data[k]
+	if e != nil && e.expired(now) {
+		s.deleteEntryLocked(k)
+		e = nil
+	}
+	if e != nil && e.kind != entrySet {
+		return 0, errWrongType
+	}
+	if e == nil {
+		if err := s.enforceKeysCap(); err != nil {
+			return 0, err
+		}
+		s.data[k] = &cacheEntry{
+			kind:    entrySet,
+			members: map[string][]byte{mk: append([]byte(nil), member...)},
+			expiry:  nil,
+		}
+		return 1, nil
+	}
+	if _, ok := e.members[mk]; ok {
+		return 0, nil
+	}
+	if len(e.members) >= maxCacheListLen {
+		return 0, fmt.Errorf("%w: set size", errCacheLimit)
+	}
+	e.members[mk] = append([]byte(nil), member...)
+	return 1, nil
+}
+
+// SRem returns 1 if member was removed, 0 if absent.
+func (s *cacheStore) SRem(key, member []byte) (int, error) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.checkKeyLen(key); err != nil {
+		return 0, err
+	}
+	k := string(key)
+	e := s.data[k]
+	if e == nil || e.expired(now) {
+		if e != nil {
+			s.deleteEntryLocked(k)
+		}
+		return 0, nil
+	}
+	if e.kind != entrySet {
+		return 0, errWrongType
+	}
+	mk := string(member)
+	if _, ok := e.members[mk]; !ok {
+		return 0, nil
+	}
+	delete(e.members, mk)
+	if len(e.members) == 0 {
+		s.deleteEntryLocked(k)
+	}
+	return 1, nil
+}
+
+// SMembers returns sorted member copies; empty slice if key missing (Redis-aligned).
+func (s *cacheStore) SMembers(key []byte) ([][]byte, error) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.checkKeyLen(key); err != nil {
+		return nil, err
+	}
+	k := string(key)
+	e, ok := s.entryLocked(k, now)
+	if !ok {
+		return [][]byte{}, nil
+	}
+	if e.kind != entrySet {
+		return nil, errWrongType
+	}
+	return setMembersSorted(e.members), nil
+}
+
+// SetNX returns 1 if key was set, 0 if key already exists (any non-expired kind).
+func (s *cacheStore) SetNX(key, value []byte, ttlSec int64) (int, error) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.checkKeyLen(key); err != nil {
+		return 0, err
+	}
+	if err := s.checkScalarVal(value); err != nil {
+		return 0, err
+	}
+	k := string(key)
+	if e, ok := s.entryLocked(k, now); ok && e != nil {
+		return 0, nil
+	}
+	if err := s.enforceKeysCap(); err != nil {
+		return 0, err
+	}
+	exp := wallExpiry(ttlSec)
+	s.data[k] = &cacheEntry{kind: entryScalar, scalar: append([]byte(nil), value...), expiry: exp}
+	s.broadcastKey(k)
+	return 1, nil
+}
+
+// Keys returns up to limit key names matching prefix (sorted). Prefix must be non-empty.
+func (s *cacheStore) Keys(prefix []byte, limit int) ([][]byte, error) {
+	if len(prefix) == 0 {
+		return nil, fmt.Errorf("%w: keys prefix required", errCacheLimit)
+	}
+	if limit <= 0 {
+		limit = defaultCSKEYSLimit
+	}
+	if limit > maxCSKEYSLimit {
+		limit = maxCSKEYSLimit
+	}
+	pfx := string(prefix)
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var matched []string
+	for k, e := range s.data {
+		if e.expired(now) {
+			s.deleteEntryLocked(k)
+			continue
+		}
+		if !strings.HasPrefix(k, pfx) {
+			continue
+		}
+		matched = append(matched, k)
+	}
+	sortStrings(matched)
+	if len(matched) > limit {
+		matched = matched[:limit]
+	}
+	out := make([][]byte, len(matched))
+	for i, k := range matched {
+		out[i] = []byte(k)
+	}
+	return out, nil
+}
+
+// --- pub/sub (blocking one-shot receive) ---
+
+type pubSubWaiter struct {
+	msg       []byte
+	ready     bool
+	cancelled bool
+}
+
+type pubSubChannel struct {
+	waiters []*pubSubWaiter
+	cond    *sync.Cond
+}
+
+type pubSub struct {
+	mu       sync.Mutex
+	channels map[string]*pubSubChannel
+	closing  bool
+}
+
+func newPubSub() *pubSub {
+	ps := &pubSub{channels: make(map[string]*pubSubChannel)}
+	return ps
+}
+
+func (ps *pubSub) channelLocked(name string) *pubSubChannel {
+	ch, ok := ps.channels[name]
+	if !ok {
+		ch = &pubSubChannel{cond: sync.NewCond(&ps.mu)}
+		ps.channels[name] = ch
+	}
+	return ch
+}
+
+func (ps *pubSub) removeWaiter(ch *pubSubChannel, w *pubSubWaiter) {
+	for i, x := range ch.waiters {
+		if x == w {
+			ch.waiters = append(ch.waiters[:i], ch.waiters[i+1:]...)
+			return
+		}
+	}
+}
+
+func (ps *pubSub) Subscribe(channel []byte, deadline time.Time) ([]byte, bool) {
+	if err := checkPubSubName(channel); err != nil {
+		return nil, false
+	}
+	name := string(channel)
+	ps.mu.Lock()
+	if ps.closing {
+		ps.mu.Unlock()
+		return nil, false
+	}
+	ch := ps.channelLocked(name)
+	w := &pubSubWaiter{}
+	ch.waiters = append(ch.waiters, w)
+
+	timedOut := false
+	timer := time.AfterFunc(time.Until(deadline), func() {
+		ps.mu.Lock()
+		timedOut = true
+		ch.cond.Broadcast()
+		ps.mu.Unlock()
+	})
+
+	for !w.ready && !w.cancelled && !ps.closing && !timedOut {
+		ch.cond.Wait()
+	}
+	timer.Stop()
+
+	var out []byte
+	if w.ready {
+		out = append([]byte(nil), w.msg...)
+	}
+	ps.removeWaiter(ch, w)
+	if len(ch.waiters) == 0 {
+		delete(ps.channels, name)
+	}
+	ps.mu.Unlock()
+	if w.ready {
+		return out, true
+	}
+	return nil, false
+}
+
+func (ps *pubSub) Publish(channel, message []byte) (int, error) {
+	if err := checkPubSubName(channel); err != nil {
+		return 0, err
+	}
+	if len(message) > maxCacheScalarLen {
+		return 0, fmt.Errorf("%w: message size", errCacheLimit)
+	}
+	name := string(channel)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.closing {
+		return 0, nil
+	}
+	ch, ok := ps.channels[name]
+	if !ok || len(ch.waiters) == 0 {
+		return 0, nil
+	}
+	n := 0
+	for _, w := range ch.waiters {
+		if w.ready {
+			continue
+		}
+		w.msg = append([]byte(nil), message...)
+		w.ready = true
+		n++
+	}
+	ch.cond.Broadcast()
+	return n, nil
+}
+
+func (ps *pubSub) Shutdown() {
+	ps.mu.Lock()
+	ps.closing = true
+	for _, ch := range ps.channels {
+		for _, w := range ch.waiters {
+			w.cancelled = true
+		}
+		ch.cond.Broadcast()
+	}
+	ps.mu.Unlock()
+}
+
+func checkPubSubName(channel []byte) error {
+	if len(channel) == 0 || len(channel) > maxCacheKeyLen {
+		return fmt.Errorf("%w: channel size", errCacheLimit)
+	}
+	return nil
 }
 
 // --- RESP ---
@@ -492,6 +849,7 @@ func respReadArray(r *bufio.Reader) ([][]byte, error) {
 
 type cacheServer struct {
 	store   *cacheStore
+	pubsub  *pubSub
 	ln      net.Listener
 	done    chan struct{}
 	closeMu sync.Mutex
@@ -514,10 +872,11 @@ func startCacheServerTCPOnly() (*cacheServer, error) {
 		return nil, err
 	}
 	s := &cacheServer{
-		store: newCacheStore(),
-		ln:    ln,
-		done:  make(chan struct{}),
-		addr:  ln.Addr().String(),
+		store:  newCacheStore(),
+		pubsub: newPubSub(),
+		ln:     ln,
+		done:   make(chan struct{}),
+		addr:   ln.Addr().String(),
 	}
 	go s.acceptLoop()
 	return s, nil
@@ -548,6 +907,7 @@ func startCacheServerUnixSocket() (*cacheServer, error) {
 	envAddr := cacheAddrUnixScheme + filepath.ToSlash(absPath)
 	s := &cacheServer{
 		store:   newCacheStore(),
+		pubsub:  newPubSub(),
 		ln:      ln,
 		done:    make(chan struct{}),
 		addr:    envAddr,
@@ -567,6 +927,8 @@ func (s *cacheServer) Close() error {
 	}
 	s.closed = true
 	s.closeMu.Unlock()
+	s.store.Shutdown()
+	s.pubsub.Shutdown()
 	err := s.ln.Close()
 	<-s.done
 	if s.sockDir != "" {
@@ -616,12 +978,16 @@ func (s *cacheServer) handleConn(conn net.Conn) {
 				_ = respWriteError(w, "wrong number of arguments for CSGET")
 				return
 			}
-			scalar, list, isList, ok := s.store.Get(parts[1])
+			scalar, list, _, kind, ok := s.store.Get(parts[1])
 			if !ok {
 				_ = respWriteBulk(w, nil) // $-1
 				continue
 			}
-			if !isList {
+			if kind == entrySet {
+				_ = respWriteError(w, errWrongType.Error())
+				continue
+			}
+			if kind == entryScalar {
 				_ = respWriteBulk(w, scalar)
 				continue
 			}
@@ -665,7 +1031,11 @@ func (s *cacheServer) handleConn(conn net.Conn) {
 				return
 			}
 			if err := s.store.Append(parts[1], parts[2]); err != nil {
-				_ = respWriteError(w, err.Error())
+				if errors.Is(err, errWrongType) {
+					_ = respWriteError(w, errWrongType.Error())
+				} else {
+					_ = respWriteError(w, err.Error())
+				}
 				continue
 			}
 			_ = respWriteSimpleString(w, "OK")
@@ -685,6 +1055,137 @@ func (s *cacheServer) handleConn(conn net.Conn) {
 				dl = &t
 			}
 			v, ok := s.store.Pop(parts[1], dl)
+			if !ok {
+				_ = respWriteBulk(w, nil)
+				continue
+			}
+			_ = respWriteBulk(w, v)
+		case "CSSADD":
+			if len(parts) != 3 {
+				_ = respWriteError(w, "wrong number of arguments for CSSADD")
+				return
+			}
+			n, err := s.store.SAdd(parts[1], parts[2])
+			if err != nil {
+				if errors.Is(err, errWrongType) {
+					_ = respWriteError(w, errWrongType.Error())
+				} else {
+					_ = respWriteError(w, err.Error())
+				}
+				continue
+			}
+			_ = respWriteInt(w, int64(n))
+		case "CSSREM":
+			if len(parts) != 3 {
+				_ = respWriteError(w, "wrong number of arguments for CSSREM")
+				return
+			}
+			n, err := s.store.SRem(parts[1], parts[2])
+			if err != nil {
+				if errors.Is(err, errWrongType) {
+					_ = respWriteError(w, errWrongType.Error())
+				} else {
+					_ = respWriteError(w, err.Error())
+				}
+				continue
+			}
+			_ = respWriteInt(w, int64(n))
+		case "CSSMEMBERS":
+			if len(parts) != 2 {
+				_ = respWriteError(w, "wrong number of arguments for CSSMEMBERS")
+				return
+			}
+			members, err := s.store.SMembers(parts[1])
+			if err != nil {
+				if errors.Is(err, errWrongType) {
+					_ = respWriteError(w, errWrongType.Error())
+				} else {
+					_ = respWriteError(w, err.Error())
+				}
+				continue
+			}
+			if len(members) == 0 {
+				if err := respWriteArrayHeader(w, 0); err != nil {
+					return
+				}
+				_ = w.Flush()
+				continue
+			}
+			_ = respWriteArrayOfBulks(w, members)
+		case "CSSETNX":
+			if len(parts) != 3 && len(parts) != 4 {
+				_ = respWriteError(w, "wrong number of arguments for CSSETNX")
+				return
+			}
+			var ttl int64
+			if len(parts) == 4 && len(parts[3]) > 0 {
+				t, err := strconv.ParseInt(string(parts[3]), 10, 64)
+				if err != nil || t < 0 {
+					_ = respWriteError(w, "invalid TTL")
+					return
+				}
+				ttl = t
+			}
+			n, err := s.store.SetNX(parts[1], parts[2], ttl)
+			if err != nil {
+				_ = respWriteError(w, err.Error())
+				continue
+			}
+			_ = respWriteInt(w, int64(n))
+		case "CSKEYS":
+			if len(parts) != 1 && len(parts) != 2 && len(parts) != 3 {
+				_ = respWriteError(w, "wrong number of arguments for CSKEYS")
+				return
+			}
+			prefix := []byte{}
+			limit := defaultCSKEYSLimit
+			if len(parts) >= 2 {
+				prefix = parts[1]
+			}
+			if len(parts) == 3 {
+				l, err := strconv.Atoi(string(parts[2]))
+				if err != nil || l < 0 {
+					_ = respWriteError(w, "invalid limit")
+					return
+				}
+				limit = l
+			}
+			keys, err := s.store.Keys(prefix, limit)
+			if err != nil {
+				_ = respWriteError(w, err.Error())
+				continue
+			}
+			if len(keys) == 0 {
+				if err := respWriteArrayHeader(w, 0); err != nil {
+					return
+				}
+				_ = w.Flush()
+				continue
+			}
+			_ = respWriteArrayOfBulks(w, keys)
+		case "CSPUBLISH":
+			if len(parts) != 3 {
+				_ = respWriteError(w, "wrong number of arguments for CSPUBLISH")
+				return
+			}
+			n, err := s.pubsub.Publish(parts[1], parts[2])
+			if err != nil {
+				_ = respWriteError(w, err.Error())
+				continue
+			}
+			_ = respWriteInt(w, int64(n))
+		case "CSSUBSCRIBE":
+			if len(parts) != 3 {
+				_ = respWriteError(w, "wrong number of arguments for CSSUBSCRIBE")
+				return
+			}
+			sec, err := strconv.ParseFloat(string(parts[2]), 64)
+			if err != nil || math.IsNaN(sec) || math.IsInf(sec, 0) || sec <= 0 || sec > maxSubscribeTimeoutSec {
+				_ = respWriteError(w, "invalid timeout")
+				return
+			}
+			deadline := time.Now().Add(time.Duration(sec * float64(time.Second)))
+			v, ok := s.pubsub.Subscribe(parts[1], deadline)
 			if !ok {
 				_ = respWriteBulk(w, nil)
 				continue

--- a/cache_server_test.go
+++ b/cache_server_test.go
@@ -61,9 +61,9 @@ func TestCacheStore_SetGetScalar(t *testing.T) {
 	if err := s.Set([]byte("k"), []byte("v"), 0); err != nil {
 		t.Fatal(err)
 	}
-	sc, list, isList, ok := s.Get([]byte("k"))
-	if !ok || isList || string(sc) != "v" || list != nil {
-		t.Fatalf("unexpected get: sc=%q list=%v isList=%v ok=%v", sc, list, isList, ok)
+	sc, list, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryScalar || string(sc) != "v" || list != nil {
+		t.Fatalf("unexpected get: sc=%q list=%v kind=%v ok=%v", sc, list, kind, ok)
 	}
 }
 
@@ -73,9 +73,9 @@ func TestCacheStore_SetReplacesList(t *testing.T) {
 	if err := s.Set([]byte("k"), []byte("x"), 0); err != nil {
 		t.Fatal(err)
 	}
-	sc, _, isList, ok := s.Get([]byte("k"))
-	if !ok || isList || string(sc) != "x" {
-		t.Fatalf("expected scalar x, got ok=%v isList=%v sc=%q", ok, isList, sc)
+	sc, _, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryScalar || string(sc) != "x" {
+		t.Fatalf("expected scalar x, got ok=%v kind=%v sc=%q", ok, kind, sc)
 	}
 }
 
@@ -83,9 +83,9 @@ func TestCacheStore_EmptyListGet(t *testing.T) {
 	s := newCacheStore()
 	_ = s.Append([]byte("k"), []byte("a"))
 	_, _ = s.Pop([]byte("k"), nil)
-	_, list, isList, ok := s.Get([]byte("k"))
-	if !ok || !isList || len(list) != 0 {
-		t.Fatalf("expected empty list, ok=%v isList=%v len=%d", ok, isList, len(list))
+	_, list, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryList || len(list) != 0 {
+		t.Fatalf("expected empty list, ok=%v kind=%v len=%d", ok, kind, len(list))
 	}
 }
 
@@ -93,12 +93,12 @@ func TestCacheStore_AppendClearsTTL(t *testing.T) {
 	s := newCacheStore()
 	_ = s.Set([]byte("k"), []byte("v"), 3600)
 	_ = s.Append([]byte("k"), []byte("x"))
-	_, _, isList, ok := s.Get([]byte("k"))
-	if !ok || !isList {
-		t.Fatalf("expected list after append promote, ok=%v isList=%v", ok, isList)
+	_, _, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryList {
+		t.Fatalf("expected list after append promote, ok=%v kind=%v", ok, kind)
 	}
 	// entry should not be expired immediately
-	_, _, _, ok2 := s.Get([]byte("k"))
+	_, _, _, _, ok2 := s.Get([]byte("k"))
 	if !ok2 {
 		t.Fatal("expected key still present")
 	}
@@ -193,9 +193,9 @@ func TestCacheStore_SetScalarUnblocksWaitingPop(t *testing.T) {
 	if popOK {
 		t.Fatal("expected pop to wake with nil when key becomes scalar")
 	}
-	sc, _, isList, ok := s.Get([]byte("k"))
-	if !ok || isList || string(sc) != "scalar" {
-		t.Fatalf("expected scalar preserved, ok=%v isList=%v sc=%q", ok, isList, sc)
+	sc, _, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryScalar || string(sc) != "scalar" {
+		t.Fatalf("expected scalar preserved, ok=%v kind=%v sc=%q", ok, kind, sc)
 	}
 }
 
@@ -363,5 +363,331 @@ func TestCacheServer_CSQUIT(t *testing.T) {
 	}
 	if _, err := r.ReadByte(); err != io.EOF {
 		t.Fatalf("expected EOF after quit, got %v", err)
+	}
+}
+
+func TestCacheStore_SetAddMembersUnique(t *testing.T) {
+	s := newCacheStore()
+	n, err := s.SAdd([]byte("g"), []byte("a"))
+	if err != nil || n != 1 {
+		t.Fatalf("sadd: n=%d err=%v", n, err)
+	}
+	n, err = s.SAdd([]byte("g"), []byte("a"))
+	if err != nil || n != 0 {
+		t.Fatalf("sadd dup: n=%d err=%v", n, err)
+	}
+	members, err := s.SMembers([]byte("g"))
+	if err != nil || len(members) != 1 || string(members[0]) != "a" {
+		t.Fatalf("smembers: %v err=%v", members, err)
+	}
+}
+
+func TestCacheStore_SetRemoveCountsAndEmptySet(t *testing.T) {
+	s := newCacheStore()
+	_, _ = s.SAdd([]byte("g"), []byte("a"))
+	n, err := s.SRem([]byte("g"), []byte("a"))
+	if err != nil || n != 1 {
+		t.Fatalf("srem: n=%d err=%v", n, err)
+	}
+	n, err = s.SRem([]byte("g"), []byte("a"))
+	if err != nil || n != 0 {
+		t.Fatalf("srem missing: n=%d err=%v", n, err)
+	}
+	members, err := s.SMembers([]byte("g"))
+	if err != nil || len(members) != 0 {
+		t.Fatalf("expected empty set, got %v", members)
+	}
+}
+
+func TestCacheStore_SetTypeReplacementRules(t *testing.T) {
+	s := newCacheStore()
+	_, _ = s.SAdd([]byte("k"), []byte("m"))
+	if err := s.Set([]byte("k"), []byte("scalar"), 0); err != nil {
+		t.Fatal(err)
+	}
+	_, err := s.SAdd([]byte("k"), []byte("x"))
+	if err != errWrongType {
+		t.Fatalf("sadd on scalar: %v", err)
+	}
+	_ = s.Append([]byte("l"), []byte("a"))
+	_, err = s.SAdd([]byte("l"), []byte("x"))
+	if err != errWrongType {
+		t.Fatalf("sadd on list: %v", err)
+	}
+	_, _ = s.SAdd([]byte("s"), []byte("m"))
+	if err := s.Append([]byte("s"), []byte("a")); err != errWrongType {
+		t.Fatalf("append on set: %v", err)
+	}
+}
+
+func TestCacheStore_SetNXConcurrentSingleWinner(t *testing.T) {
+	s := newCacheStore()
+	var wg sync.WaitGroup
+	wins := make([]int, 20)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			n, err := s.SetNX([]byte("lock"), []byte("v"), 0)
+			if err != nil {
+				t.Errorf("setnx: %v", err)
+				return
+			}
+			if n == 1 {
+				wins[idx] = 1
+			}
+		}(i)
+	}
+	wg.Wait()
+	total := 0
+	for _, w := range wins {
+		total += w
+	}
+	if total != 1 {
+		t.Fatalf("expected 1 winner, got %d", total)
+	}
+}
+
+func TestCacheStore_SetNXExpiredKeyCanBeReclaimed(t *testing.T) {
+	s := newCacheStore()
+	n, err := s.SetNX([]byte("k"), []byte("a"), 1)
+	if err != nil || n != 1 {
+		t.Fatalf("setnx: n=%d err=%v", n, err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	n, err = s.SetNX([]byte("k"), []byte("b"), 0)
+	if err != nil || n != 1 {
+		t.Fatalf("reclaim: n=%d err=%v", n, err)
+	}
+	sc, _, _, kind, ok := s.Get([]byte("k"))
+	if !ok || kind != entryScalar || string(sc) != "b" {
+		t.Fatalf("get after reclaim: ok=%v sc=%q", ok, sc)
+	}
+}
+
+func TestCacheServer_CSSADD_CSSMEMBERS_RESP(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	conn := dialCacheServer(t, srv)
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSADD", "g", "a"))
+	if readProtoLine(t, r) != ":1" {
+		t.Fatal("sadd")
+	}
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSMEMBERS", "g"))
+	if readProtoLine(t, r) != "*1" {
+		t.Fatal("smembers header")
+	}
+	if string(readBulkString(t, r)) != "a" {
+		t.Fatal("member")
+	}
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSMEMBERS", "missing"))
+	if readProtoLine(t, r) != "*0" {
+		t.Fatal("smembers missing")
+	}
+}
+
+func TestCacheServer_CSSETNXCreatesAndRejectsExisting(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	conn := dialCacheServer(t, srv)
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSETNX", "k", "v"))
+	if readProtoLine(t, r) != ":1" {
+		t.Fatal("setnx create")
+	}
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSETNX", "k", "other"))
+	if readProtoLine(t, r) != ":0" {
+		t.Fatal("setnx reject")
+	}
+}
+
+func TestCacheServer_CSKEYSPrefixAndAllTypes(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	conn := dialCacheServer(t, srv)
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSET", "app:scalar", "v"))
+	readProtoLine(t, r)
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSAPPEND", "app:list", "a"))
+	readProtoLine(t, r)
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSADD", "app:set", "m"))
+	readProtoLine(t, r)
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSET", "other", "x"))
+	readProtoLine(t, r)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSKEYS", "app:", "100"))
+	line := readProtoLine(t, r)
+	if line != "*3" {
+		t.Fatalf("keys want *3, got %q", line)
+	}
+}
+
+func TestCacheServer_PubSubPublishUnblocksSubscribers(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	var wg sync.WaitGroup
+	var got []byte
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c := dialCacheServer(t, srv)
+		defer c.Close()
+		r := bufio.NewReader(c)
+		_, _ = io.WriteString(c, respStringArrayCmd("CSSUBSCRIBE", "ch", "5"))
+		got = readBulkString(t, r)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	pub := dialCacheServer(t, srv)
+	defer pub.Close()
+	pr := bufio.NewReader(pub)
+	_, _ = io.WriteString(pub, respStringArrayCmd("CSPUBLISH", "ch", "hello"))
+	if readProtoLine(t, pr) != ":1" {
+		t.Fatal("publish count")
+	}
+
+	wg.Wait()
+	if string(got) != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCacheServer_PubSubMultipleSubscribersAndPublishCount(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	startSub := func(out *[]byte) *sync.WaitGroup {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := dialCacheServer(t, srv)
+			defer c.Close()
+			r := bufio.NewReader(c)
+			_, _ = io.WriteString(c, respStringArrayCmd("CSSUBSCRIBE", "fan", "5"))
+			*out = readBulkString(t, r)
+		}()
+		return &wg
+	}
+	var a, b []byte
+	wg1 := startSub(&a)
+	wg2 := startSub(&b)
+	time.Sleep(50 * time.Millisecond)
+
+	pub := dialCacheServer(t, srv)
+	defer pub.Close()
+	pr := bufio.NewReader(pub)
+	_, _ = io.WriteString(pub, respStringArrayCmd("CSPUBLISH", "fan", "msg"))
+	if readProtoLine(t, pr) != ":2" {
+		t.Fatal("publish count")
+	}
+	wg1.Wait()
+	wg2.Wait()
+	if string(a) != "msg" || string(b) != "msg" {
+		t.Fatalf("a=%q b=%q", a, b)
+	}
+}
+
+func TestCacheServer_CloseUnblocksSubscribersAndPops(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = srv.store.Append([]byte("q"), []byte("only"))
+	_, _ = srv.store.Pop([]byte("q"), nil)
+
+	popDone := make(chan struct{})
+	go func() {
+		defer close(popDone)
+		_, _ = srv.store.Pop([]byte("q"), nil)
+	}()
+
+	subDone := make(chan struct{})
+	go func() {
+		defer close(subDone)
+		_, _ = srv.pubsub.Subscribe([]byte("c"), time.Now().Add(30*time.Second))
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	_ = srv.Close()
+
+	select {
+	case <-popDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pop not unblocked")
+	}
+	select {
+	case <-subDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscribe not unblocked")
+	}
+}
+
+func TestCacheServer_CSKEYSRejectsEmptyPrefix(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	conn := dialCacheServer(t, srv)
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSKEYS", "", "10"))
+	line := readProtoLine(t, r)
+	if !strings.HasPrefix(line, "-ERR") {
+		t.Fatalf("want ERR for empty prefix, got %q", line)
+	}
+}
+
+func TestCacheStore_SRemDeletesEmptySet(t *testing.T) {
+	s := newCacheStore()
+	_, _ = s.SAdd([]byte("g"), []byte("only"))
+	_, _ = s.SRem([]byte("g"), []byte("only"))
+	_, _, _, _, ok := s.Get([]byte("g"))
+	if ok {
+		t.Fatal("empty set should remove key")
+	}
+}
+
+func TestCacheServer_CSGETWrongTypeOnSet(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	conn := dialCacheServer(t, srv)
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSSADD", "s", "m"))
+	readProtoLine(t, r)
+	_, _ = io.WriteString(conn, respStringArrayCmd("CSGET", "s"))
+	line := readProtoLine(t, r)
+	if !strings.HasPrefix(line, "-ERR") || !strings.Contains(line, "wrong type") {
+		t.Fatalf("want wrong type err, got %q", line)
 	}
 }

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -566,6 +566,7 @@ type PythonWorker struct {
 	DialNet    string // "unix" or "tcp"
 	DialAddr   string // socket path or host:port
 	CacheAddr  string // CADDYSNAKE_CACHE_ADDR: unix://path (Unix) or 127.0.0.1:port (Windows); empty = omit env
+	WorkerID   string // CADDYSNAKE_WORKER_ID: stable index 0..N-1 within the worker group
 	EnvFiles   []string
 	EnvVars    map[string]string
 
@@ -574,7 +575,7 @@ type PythonWorker struct {
 	Proxy     *httputil.ReverseProxy
 }
 
-func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBin, scriptPath, cacheAddr string, envFiles []string, envVars map[string]string) (*PythonWorker, error) {
+func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBin, scriptPath, cacheAddr, workerID string, envFiles []string, envVars map[string]string) (*PythonWorker, error) {
 	var socket *os.File
 	var sockDir string
 	var err error
@@ -621,6 +622,7 @@ func NewPythonWorker(iface, app, workingDir, venv, lifespan, pyRuntime, pythonBi
 		DialNet:    dialNet,
 		DialAddr:   dialAddr,
 		CacheAddr:  cacheAddr,
+		WorkerID:   workerID,
 		EnvFiles:   cloneEnvFiles(envFiles),
 		EnvVars:    cloneEnvVars(envVars),
 	}
@@ -677,7 +679,7 @@ func (w *PythonWorker) Start() error {
 	if err != nil {
 		return err
 	}
-	w.Cmd.Env = buildWorkerEnv(os.Environ(), fileVars, w.EnvVars, workerInternalEnv(w.Interface, w.CacheAddr)...)
+	w.Cmd.Env = buildWorkerEnv(os.Environ(), fileVars, w.EnvVars, workerInternalEnv(w.Interface, w.CacheAddr, w.WorkerID)...)
 	setSysProcAttr(w.Cmd)
 
 	if err := w.Cmd.Start(); err != nil {
@@ -815,7 +817,7 @@ func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string
 	errs := make([]error, count)
 	workers := make([]*PythonWorker, count)
 	for i := 0; i < count; i++ {
-		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, runtime, pythonBin, scriptPath, cacheAddr, envFiles, envVars)
+		workers[i], errs[i] = NewPythonWorker(iface, app, workingDir, venv, lifespan, runtime, pythonBin, scriptPath, cacheAddr, strconv.Itoa(i), envFiles, envVars)
 	}
 	wg := &PythonWorkerGroup{
 		Workers:    workers,

--- a/cmd/cli/caddysnake/__init__.py
+++ b/cmd/cli/caddysnake/__init__.py
@@ -3,6 +3,7 @@ from .kv_cache import (
     CacheConfigurationError,
     CacheError,
     cache,
+    worker_id,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "CacheConfigurationError",
     "CacheError",
     "cache",
+    "worker_id",
 ]

--- a/cmd/cli/caddysnake/kv_cache.py
+++ b/cmd/cli/caddysnake/kv_cache.py
@@ -4,8 +4,9 @@ Python workers connect using the environment variable ``CADDYSNAKE_CACHE_ADDR``
 (``unix://...`` on Unix, ``127.0.0.1:port`` on Windows). Use ``Cache`` or the module-level
 ``cache`` singleton when that variable is set (typically process workers under Caddy).
 
-Each key stores either a **scalar** (one blob of bytes) or a **list** (FIFO queue of
-blobs). Method docstrings on ``Cache`` describe how operations behave in each mode.
+Each key stores either a **scalar** (one blob of bytes), a **list** (FIFO queue of
+blobs), or a **set** (unique member blobs). Method docstrings on ``Cache`` describe
+how operations behave in each mode.
 
 The ``cache`` name exported from this module is a single shared ``Cache()`` instance for
 convenience (same methods as the class).
@@ -20,6 +21,7 @@ from typing import Any
 ENV_ADDR = "CADDYSNAKE_CACHE_ADDR"
 ENV_IFACE = "CADDYSNAKE_WORKER_INTERFACE"
 ENV_TIMEOUT = "CADDYSNAKE_CACHE_TIMEOUT"
+ENV_WORKER_ID = "CADDYSNAKE_WORKER_ID"
 
 
 class CacheError(RuntimeError):
@@ -28,6 +30,17 @@ class CacheError(RuntimeError):
 
 class CacheConfigurationError(CacheError):
     """Cache is not available (missing env or wrong runtime)."""
+
+
+def worker_id() -> int | None:
+    """Return ``CADDYSNAKE_WORKER_ID`` as an int, or ``None`` if unset or invalid."""
+    raw = os.environ.get(ENV_WORKER_ID)
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
 
 
 def _socket_module():
@@ -169,44 +182,29 @@ class Cache:
     closes. Suitable for small payloads and cross-worker coordination; not a substitute
     for Redis or a database (see the docs).
 
-    **Scalar vs list:** ``set`` stores a **scalar**. ``append`` builds or extends a
-    **list**; if the key held a scalar, it becomes ``[old_scalar, new_chunk]``. ``get``
-    returns ``bytes`` for a scalar, ``list[bytes]`` for a list (possibly empty), or
-    ``None`` if the key is missing or expired. ``pop`` only applies to **list** keys
-    (FIFO); it returns ``None`` for scalars, missing keys, or when a timed wait expires
-    before an element arrives.
+    **Scalar vs list vs set:** ``set`` stores a **scalar**. ``append`` builds or extends a
+    **list**. ``sadd``/``srem``/``smembers`` operate on **sets**. ``get`` returns ``bytes``
+    for a scalar, ``list[bytes]`` for a list, or ``None`` if missing or expired.
+
+    **Blocking receive:** ``pop`` and ``subscribe`` block on the server when ``timeout`` is
+    set. ``subscribe`` requires a timeout (one-shot blocking receive, not persistent
+    Redis-style pub/sub).
 
     **Errors:** Failures from the server or network raise ``CacheError``. Missing
-    ``CADDYSNAKE_CACHE_ADDR`` (or bad address) raises ``CacheConfigurationError``.
-
-    **Async:** ``aset``, ``aget``, ``adelete``, ``aappend``, and ``apop`` run the
-    blocking counterparts in ``asyncio.to_thread`` for use in ASGI code.
-
-    Example::
-
-        from caddysnake import cache
-
-        cache.set("user:42:session", session_bytes, ttl=3600)
-        raw = cache.get("user:42:session")
-
-        cache.append("jobs", b"task-1")
-        cache.append("jobs", b"task-2")
-        first = cache.pop("jobs")
+    ``CADDYSNAKE_CACHE_ADDR`` raises ``CacheConfigurationError``.
     """
 
     __slots__ = ()
 
-    def _open_socket(self, mod):
+    def _open_socket(self, mod, timeout: float | None = None):
         addr = _require_addr()
+        t = _timeout_sec() if timeout is None else timeout
         if addr.startswith("unix://"):
             path = addr[7:]
-            # ESGI uses gevent for the Go-facing server, but gevent's client
-            # AF_UNIX path has been unreliable; stdlib socket is fine here (short
-            # local IPC and does not block other greenlets' I/O meaningfully).
             import socket as stdsocket
 
             sock = stdsocket.socket(stdsocket.AF_UNIX, stdsocket.SOCK_STREAM)
-            sock.settimeout(_timeout_sec())
+            sock.settimeout(t)
             try:
                 sock.connect(path)
             except OSError as e:
@@ -215,7 +213,7 @@ class Cache:
             return sock
         host, port = _parse_tcp_host_port(addr)
         sock = mod.socket(mod.AF_INET, mod.SOCK_STREAM)
-        sock.settimeout(_timeout_sec())
+        sock.settimeout(t)
         try:
             sock.connect((host, port))
         except OSError as e:
@@ -233,20 +231,19 @@ class Cache:
         finally:
             sock.close()
 
+    def _roundtrip_blocking(self, parts: list[bytes], wait_sec: float) -> Any:
+        mod = _socket_module()
+        sock_timeout = max(_timeout_sec(), wait_sec + 5.0)
+        sock = self._open_socket(mod, timeout=sock_timeout)
+        buf = bytearray()
+        try:
+            sock.sendall(_encode_cmd(parts))
+            return _read_reply(sock, buf)
+        finally:
+            sock.close()
+
     def set(self, key: str | bytes, value: str | bytes, ttl: int | None = None) -> None:
-        """Store a scalar value under ``key``, replacing any previous value (scalar or list).
-
-        After ``set``, the key is a **scalar** until ``append`` is used.
-
-        Args:
-            key: Cache key (UTF-8 if ``str``).
-            value: Value to store (UTF-8 if ``str``).
-            ttl: Optional time-to-live in **seconds** (integer). Omit or ``None`` for no
-                expiry on this key (until deleted or overwritten).
-
-        Raises:
-            CacheError: Server rejected the operation (limits, I/O, etc.).
-        """
+        """Store a scalar value under ``key``, replacing any previous value."""
         kb = _to_bytes(key)
         vb = _to_bytes(value)
         if ttl is None:
@@ -255,16 +252,7 @@ class Cache:
             self._roundtrip([b"CSSET", kb, vb, str(int(ttl)).encode()])
 
     def get(self, key: str | bytes) -> bytes | list[bytes] | None:
-        """Return the value at ``key``, or ``None`` if missing or expired.
-
-        Returns:
-            * ``bytes`` — key holds a **scalar** (via ``set``).
-            * ``list[bytes]`` — key holds a **list** (via ``append``); may be empty.
-            * ``None`` — no such key, expired, or invalid key per server limits.
-
-        Raises:
-            CacheError: Server or protocol error.
-        """
+        """Return the value at ``key``, or ``None`` if missing or expired."""
         r = self._roundtrip([b"CSGET", _to_bytes(key)])
         if r is None:
             return None
@@ -273,76 +261,115 @@ class Cache:
         return r
 
     def delete(self, key: str | bytes) -> int:
-        """Remove ``key`` if it exists.
-
-        Returns:
-            ``1`` if a key was removed, ``0`` if it was already absent or expired.
-
-        Raises:
-            CacheError: Server or protocol error.
-        """
+        """Remove ``key`` if it exists. Returns ``1`` if removed, ``0`` otherwise."""
         return int(self._roundtrip([b"CSDEL", _to_bytes(key)]))
 
     def append(self, key: str | bytes, value: str | bytes) -> None:
-        """Append a chunk to the **list** at ``key``.
-
-        If the key does not exist, starts a one-element list. If it holds a **scalar**,
-        the scalar and ``value`` become the first two list elements. **TTL is cleared**
-        when a key becomes or stays a list.
-
-        Raises:
-            CacheError: Server rejected the operation (e.g. list size/value limits).
-        """
+        """Append a chunk to the **list** at ``key``."""
         self._roundtrip([b"CSAPPEND", _to_bytes(key), _to_bytes(value)])
 
     def pop(self, key: str | bytes, timeout: float | None = None) -> bytes | None:
-        """Pop the **first** element from the list at ``key`` (FIFO).
-
-        Blocks only when ``timeout`` is set: waits up to that many **seconds** for an
-        element to appear. Another worker can ``append`` while you wait.
-
-        Returns:
-            * ``bytes`` — first queued element was removed and returned.
-            * ``None`` — key missing, expired, key holds a **scalar** (not a list), list
-              empty at observation time, or ``timeout`` elapsed with no element.
-
-        Args:
-            key: Cache key.
-            timeout: Maximum seconds to wait for a list element; ``None`` returns
-                immediately (non-blocking pop).
-
-        Raises:
-            CacheError: Server or protocol error.
-        """
+        """Pop the **first** element from the list at ``key`` (FIFO)."""
         kb = _to_bytes(key)
         if timeout is None:
             r = self._roundtrip([b"CSPOP", kb])
         else:
-            r = self._roundtrip([b"CSPOP", kb, str(float(timeout)).encode()])
+            r = self._roundtrip_blocking(
+                [b"CSPOP", kb, str(float(timeout)).encode()], float(timeout)
+            )
+        return r
+
+    def sadd(self, key: str | bytes, member: str | bytes) -> int:
+        """Add ``member`` to the **set** at ``key``. Returns ``1`` if new, ``0`` if present."""
+        return int(self._roundtrip([b"CSSADD", _to_bytes(key), _to_bytes(member)]))
+
+    def srem(self, key: str | bytes, member: str | bytes) -> int:
+        """Remove ``member`` from the set at ``key``. Returns ``1`` if removed, ``0`` if absent."""
+        return int(self._roundtrip([b"CSSREM", _to_bytes(key), _to_bytes(member)]))
+
+    def smembers(self, key: str | bytes) -> list[bytes]:
+        """Return all members of the set at ``key`` (empty list if missing)."""
+        r = self._roundtrip([b"CSSMEMBERS", _to_bytes(key)])
+        if not isinstance(r, list):
+            return []
+        return r
+
+    def setnx(self, key: str | bytes, value: str | bytes, ttl: int | None = None) -> bool:
+        """Set scalar ``key`` only if absent. Returns ``True`` if set, ``False`` if exists."""
+        kb = _to_bytes(key)
+        vb = _to_bytes(value)
+        if ttl is None:
+            n = self._roundtrip([b"CSSETNX", kb, vb])
+        else:
+            n = self._roundtrip([b"CSSETNX", kb, vb, str(int(ttl)).encode()])
+        return int(n) == 1
+
+    def keys(self, prefix: str | bytes, limit: int = 1000) -> list[bytes]:
+        """List key names matching ``prefix`` (up to ``limit``, max 1000).
+
+        ``prefix`` must be non-empty (server rejects full keyspace scans).
+        """
+        pb = _to_bytes(prefix)
+        if not pb:
+            raise ValueError("keys prefix must be non-empty")
+        r = self._roundtrip([b"CSKEYS", pb, str(int(limit)).encode()])
+        if not isinstance(r, list):
+            return []
+        return r
+
+    def publish(self, channel: str | bytes, message: str | bytes) -> int:
+        """Deliver ``message`` to waiters blocked on ``channel``. Returns waiter count."""
+        return int(self._roundtrip([b"CSPUBLISH", _to_bytes(channel), _to_bytes(message)]))
+
+    def subscribe(self, channel: str | bytes, timeout: float) -> bytes | None:
+        """Block up to ``timeout`` seconds for one message on ``channel`` (required).
+
+        One-shot blocking receive; not a persistent subscription. Returns ``None`` on
+        timeout with no message.
+        """
+        if timeout <= 0:
+            raise ValueError("subscribe timeout must be positive")
+        r = self._roundtrip_blocking(
+            [b"CSSUBSCRIBE", _to_bytes(channel), str(float(timeout)).encode()],
+            float(timeout),
+        )
         return r
 
     async def aset(self, key: str | bytes, value: str | bytes, ttl: int | None = None) -> None:
-        """Async wrapper for ``set`` (runs in a worker thread via ``asyncio.to_thread``)."""
         await asyncio.to_thread(self.set, key, value, ttl)
 
     async def aget(self, key: str | bytes) -> bytes | list[bytes] | None:
-        """Async wrapper for ``get`` (``asyncio.to_thread``)."""
         return await asyncio.to_thread(self.get, key)
 
     async def adelete(self, key: str | bytes) -> int:
-        """Async wrapper for ``delete`` (``asyncio.to_thread``)."""
         return await asyncio.to_thread(self.delete, key)
 
     async def aappend(self, key: str | bytes, value: str | bytes) -> None:
-        """Async wrapper for ``append`` (``asyncio.to_thread``)."""
         await asyncio.to_thread(self.append, key, value)
 
     async def apop(self, key: str | bytes, timeout: float | None = None) -> bytes | None:
-        """Async wrapper for ``pop`` (``asyncio.to_thread``).
-
-        The blocking wait still runs in a thread; tune ``timeout`` to bound wait time.
-        """
         return await asyncio.to_thread(self.pop, key, timeout)
+
+    async def asadd(self, key: str | bytes, member: str | bytes) -> int:
+        return await asyncio.to_thread(self.sadd, key, member)
+
+    async def asrem(self, key: str | bytes, member: str | bytes) -> int:
+        return await asyncio.to_thread(self.srem, key, member)
+
+    async def asmembers(self, key: str | bytes) -> list[bytes]:
+        return await asyncio.to_thread(self.smembers, key)
+
+    async def asetnx(self, key: str | bytes, value: str | bytes, ttl: int | None = None) -> bool:
+        return await asyncio.to_thread(self.setnx, key, value, ttl)
+
+    async def akeys(self, prefix: str | bytes = "", limit: int = 1000) -> list[bytes]:
+        return await asyncio.to_thread(self.keys, prefix, limit)
+
+    async def apublish(self, channel: str | bytes, message: str | bytes) -> int:
+        return await asyncio.to_thread(self.publish, channel, message)
+
+    async def asubscribe(self, channel: str | bytes, timeout: float) -> bytes | None:
+        return await asyncio.to_thread(self.subscribe, channel, timeout)
 
 
 cache = Cache()

--- a/cmd/cli/tests/test_cache.py
+++ b/cmd/cli/tests/test_cache.py
@@ -1,10 +1,12 @@
 import pytest
 
 from caddysnake.kv_cache import (
+    ENV_WORKER_ID,
     Cache,
     CacheConfigurationError,
     CacheError,
     _encode_cmd,
+    worker_id,
 )
 
 
@@ -23,9 +25,10 @@ class _FakeSock:
     def __init__(self, to_recv: bytes):
         self._data = to_recv
         self.sent = b""
+        self.timeout = None
 
-    def settimeout(self, _t):
-        pass
+    def settimeout(self, t):
+        self.timeout = t
 
     def connect(self, _addr):
         pass
@@ -33,11 +36,15 @@ class _FakeSock:
     def sendall(self, data):
         self.sent = data
 
-    def recv(self, _n):
+    def recv(self, n):
         if not self._data:
             return b""
-        chunk = self._data
-        self._data = b""
+        if len(self._data) <= n:
+            chunk = self._data
+            self._data = b""
+            return chunk
+        chunk = self._data[:n]
+        self._data = self._data[n:]
         return chunk
 
     def close(self):
@@ -48,31 +55,35 @@ class _FakeMod:
     AF_INET = 2
     SOCK_STREAM = 1
     _response = b""
+    last_sock: _FakeSock | None = None
 
     @classmethod
     def socket(cls, *_a, **_k):
-        return _FakeSock(cls._response)
+        cls.last_sock = _FakeSock(cls._response)
+        return cls.last_sock
+
+
+def _patch_cache(monkeypatch):
+    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
+    monkeypatch.delenv("CADDYSNAKE_WORKER_INTERFACE", raising=False)
+    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
 
 
 def test_get_miss_roundtrip(monkeypatch):
-    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
-    monkeypatch.delenv("CADDYSNAKE_WORKER_INTERFACE", raising=False)
+    _patch_cache(monkeypatch)
     _FakeMod._response = b"$-1\r\n"
-    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
     assert Cache().get("missing") is None
 
 
 def test_delete_returns_int(monkeypatch):
-    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
+    _patch_cache(monkeypatch)
     _FakeMod._response = b":1\r\n"
-    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
     assert Cache().delete("k") == 1
 
 
 def test_server_err_raises(monkeypatch):
-    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
+    _patch_cache(monkeypatch)
     _FakeMod._response = b"-ERR something wrong\r\n"
-    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
     with pytest.raises(CacheError, match="something wrong"):
         Cache().get("k")
 
@@ -85,7 +96,120 @@ def test_missing_cache_addr(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_aget(monkeypatch):
-    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
+    _patch_cache(monkeypatch)
     _FakeMod._response = b"$3\r\nbye\r\n"
-    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
     assert await Cache().aget("k") == b"bye"
+
+
+def test_cache_set_methods_encode_commands(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b":1\r\n"
+    Cache().sadd("g", b"m")
+    assert _FakeMod.last_sock is not None and b"CSSADD" in _FakeMod.last_sock.sent
+    _FakeMod._response = b":1\r\n"
+    Cache().srem("g", b"m")
+    assert _FakeMod.last_sock is not None and b"CSSREM" in _FakeMod.last_sock.sent
+    _FakeMod._response = b"*1\r\n$1\r\nm\r\n"
+    assert Cache().smembers("g") == [b"m"]
+
+
+def test_cache_set_members_empty_array(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b"*0\r\n"
+    assert Cache().smembers("missing") == []
+
+
+def test_cache_setnx_return_bool(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b":1\r\n"
+    assert Cache().setnx("k", b"v") is True
+    _FakeMod._response = b":0\r\n"
+    assert Cache().setnx("k", b"v") is False
+
+
+def test_cache_setnx_ttl_argument_encoding(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b":1\r\n"
+    Cache().setnx("k", b"v", ttl=60)
+    assert _FakeMod.last_sock is not None
+    assert b"60" in _FakeMod.last_sock.sent
+
+
+def test_cache_keys_pattern_encoding_and_reply(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b"*2\r\n$3\r\napp\r\n$4\r\napp2\r\n"
+    keys = Cache().keys("app", limit=10)
+    assert keys == [b"app", b"app2"]
+    assert _FakeMod.last_sock is not None
+    assert b"CSKEYS" in _FakeMod.last_sock.sent
+
+
+def test_cache_publish_subscribe_commands(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b":2\r\n"
+    assert Cache().publish("ch", b"msg") == 2
+    _FakeMod._response = b"$3\r\nmsg\r\n"
+    assert Cache().subscribe("ch", timeout=1.0) == b"msg"
+
+
+def test_cache_subscribe_timeout_and_eof_errors(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b"$-1\r\n"
+    assert Cache().subscribe("ch", timeout=0.1) is None
+    with pytest.raises(ValueError):
+        Cache().subscribe("ch", timeout=0)
+
+
+def test_worker_id_environment_accessor(monkeypatch):
+    monkeypatch.delenv(ENV_WORKER_ID, raising=False)
+    assert worker_id() is None
+    monkeypatch.setenv(ENV_WORKER_ID, "2")
+    assert worker_id() == 2
+    monkeypatch.setenv(ENV_WORKER_ID, "bad")
+    assert worker_id() is None
+
+
+@pytest.mark.asyncio
+async def test_async_wrappers_for_new_methods(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b":1\r\n"
+    c = Cache()
+    assert await c.asadd("g", b"a") == 1
+    _FakeMod._response = b":1\r\n"
+    assert await c.asrem("g", b"a") == 1
+    _FakeMod._response = b"*0\r\n"
+    assert await c.asmembers("g") == []
+    _FakeMod._response = b":1\r\n"
+    assert await c.asetnx("k", b"v") is True
+    _FakeMod._response = b"*0\r\n"
+    assert await c.akeys("p") == []
+    _FakeMod._response = b":0\r\n"
+    assert await c.apublish("c", b"m") == 0
+    _FakeMod._response = b"$-1\r\n"
+    assert await c.asubscribe("c", timeout=0.01) is None
+
+
+def test_new_methods_require_cache_addr(monkeypatch):
+    monkeypatch.delenv("CADDYSNAKE_CACHE_ADDR", raising=False)
+    c = Cache()
+    with pytest.raises(CacheConfigurationError):
+        c.sadd("k", b"v")
+    with pytest.raises(CacheConfigurationError):
+        c.srem("k", b"v")
+    with pytest.raises(CacheConfigurationError):
+        c.smembers("k")
+    with pytest.raises(CacheConfigurationError):
+        c.setnx("k", b"v")
+    with pytest.raises(CacheConfigurationError):
+        c.keys("p")
+    with pytest.raises(CacheConfigurationError):
+        c.publish("c", b"m")
+    with pytest.raises(CacheConfigurationError):
+        c.subscribe("c", timeout=1.0)
+
+
+def test_partial_resp_reads_for_new_array_replies(monkeypatch):
+    _patch_cache(monkeypatch)
+    _FakeMod._response = b"*1\r\n$1\r\n"
+    _FakeMod._response += b"a\r\n"
+    assert Cache().smembers("g") == [b"a"]

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -414,24 +414,59 @@ Caddy sets these automatically for eligible workers:
 | --- | --- |
 | **`CADDYSNAKE_CACHE_ADDR`** | Socket path (`unix://…`) or `host:port` for the cache |
 | **`CADDYSNAKE_WORKER_INTERFACE`** | Worker kind (`wsgi`, `asgi`, `esgi`, …); selects compatible client socket APIs (e.g. gevent for ESGI) |
+| **`CADDYSNAKE_WORKER_ID`** | Stable worker index **`0`…`N-1`** within the worker group (reused after reload; combine with conn/generation in app keys) |
 | **`CADDYSNAKE_CACHE_TIMEOUT`** | Hint for client read/connect timeouts (seconds) |
 
 If **`CADDYSNAKE_CACHE_ADDR`** is unset, the cache client is not available (for example, thread workers or configurations that omit the shared cache).
 
 ### How values are stored
 
-Each key is in one of two shapes:
+Each key is in one of three shapes:
 
 | Shape | How it is created | What `get` returns |
 | --- | --- | --- |
 | **Scalar** | `set(key, value)` | `bytes` |
 | **List** (FIFO) | `append` on a missing key, or on a scalar (scalar becomes first element) | `list[bytes]` (may be empty) |
+| **Set** | `sadd(key, member)` | Use **`smembers`** — `get` returns an error for set keys |
 
-- **`set`** replaces whatever was there (scalar or list) with a new scalar. Optional **`ttl`** is in whole **seconds**; omit for no expiry until delete/overwrite.
+- **`set`** replaces whatever was there (scalar, list, or set) with a new scalar. Optional **`ttl`** is in whole **seconds**; omit for no expiry until delete/overwrite.
 - **`get`** returns `None` if the key is missing or expired.
 - **`delete`** returns `1` if a key was removed, `0` if nothing was stored under that key.
 - **`append`** appends one chunk to the list. If the key held a scalar, the value becomes `[old_scalar, new_chunk]`. **TTL is cleared** when working with list data.
-- **`pop`** removes the **first** list element (FIFO). It returns `None` if the key is missing, expired, holds a **scalar**, or the list is empty when **`timeout`** is omitted. With **`timeout=float(seconds)`**, the server waits up to that long for another worker to **`append`**; it still returns `None` if the wait elapses with no element. This is the usual pattern for **cross-worker queues** (one worker blocks on `pop`, others `append`).
+- **`pop`** removes the **first** list element (FIFO). It returns `None` if the key is missing, expired, holds a **scalar** or **set**, or the list is empty when **`timeout`** is omitted. With **`timeout=float(seconds)`**, the server waits up to that long for another worker to **`append`**.
+- **`sadd` / `srem` / `smembers`** manage **set** membership (unique members). **`smembers`** returns an empty list for a missing key. Remove stale members with **`srem`** on disconnect (sets have no per-member TTL).
+- **`setnx(key, value, ttl=None)`** sets a scalar only if the key is absent; returns **`True`** if set, **`False`** if another value exists.
+- **`keys(prefix, limit=1000)`** lists key names (as **`bytes`**) matching a **non-empty** prefix (hard cap **1000**). All workers share one cache — **prefix keys** (e.g. `myapp:group:foo`) to avoid collisions.
+- **`publish(channel, message)`** delivers to workers **currently blocked** on **`subscribe(channel, timeout)`** (one-shot blocking receive, not persistent Redis-style pub/sub). Returns the number of waiters notified.
+- **`subscribe(channel, timeout)`** requires a **positive timeout** (seconds). Returns **`bytes`** or **`None`** on timeout.
+
+:::note Security and limitations
+
+There is **no tenant isolation** between workers or dynamic apps on the same handler — any worker can read, delete, or enumerate keys. Use app-specific prefixes. **`CSGROUPSEND`** (atomic set fan-out) is not built in; use **`smembers`** + **`append`** in app code with known race trade-offs, or external Redis for full channel-layer semantics.
+
+:::
+
+### Wire protocol (CS* commands)
+
+All commands are RESP2 arrays of bulk strings. Replies are bulk (`$…`), integer (`:…`), array (`*…`), simple string (`+OK`), or error (`-ERR …`).
+
+| Command | Arguments | Reply | Notes |
+| --- | --- | --- | --- |
+| **`CSGET`** | key | bulk, array, or `$-1` | Set keys → `-ERR wrong type` |
+| **`CSSET`** | key value [ttl_sec] | `+OK` | Overwrites any prior type |
+| **`CSDEL`** | key | `:0` / `:1` | |
+| **`CSAPPEND`** | key chunk | `+OK` | List only; wrong type on sets |
+| **`CSPOP`** | key [timeout_sec] | bulk or `$-1` | FIFO; blocks when timeout set |
+| **`CSSADD`** | key member | `:0` / `:1` | Creates set if missing |
+| **`CSSREM`** | key member | `:0` / `:1` | Deletes key when last member removed |
+| **`CSSMEMBERS`** | key | `*N` bulks | `*0` if missing (Redis-aligned) |
+| **`CSSETNX`** | key value [ttl_sec] | `:0` / `:1` | Scalar only if absent |
+| **`CSKEYS`** | prefix [limit] | `*N` bulks | **Prefix required**; limit ≤ 1000 |
+| **`CSPUBLISH`** | channel message | `:N` | `N` = waiters notified |
+| **`CSSUBSCRIBE`** | channel timeout_sec | bulk or `$-1` | Timeout required; max **300** s |
+| **`CSQUIT`** | — | `+OK` | Closes connection |
+
+Blocking **`CSPOP`** and **`CSSUBSCRIBE`** hold a server goroutine until data arrives, timeout, or cache shutdown (Caddy reload).
 
 ### Python API
 
@@ -492,15 +527,39 @@ item = cache.pop("jobs")
 item = cache.pop("jobs", timeout=30.0)
 ```
 
-#### `cache.aset` / `cache.aget` / `cache.adelete` / `cache.aappend` / `cache.apop`
+#### `cache.aset` / `cache.aget` / … / `cache.apop`
 
-Async variants for ASGI: each call runs the blocking client in `asyncio.to_thread`, so the event loop stays responsive.
+Async variants for ASGI: each call runs the blocking client in `asyncio.to_thread`.
+
+#### `cache.sadd` / `cache.srem` / `cache.smembers`
+
+Set operations for group rosters and connection registries.
+
+#### `cache.setnx(key, value, ttl=None) -> bool`
+
+Atomic insert-if-absent (scalar only).
+
+#### `cache.keys(prefix, limit=1000) -> list[bytes]`
+
+Prefix key listing (admin/debug; **`prefix` required**).
+
+#### `cache.publish` / `cache.subscribe`
+
+One-shot blocking fan-out: **`subscribe`** must pass **`timeout`** (seconds).
+
+#### `worker_id() -> int | None`
+
+Reads **`CADDYSNAKE_WORKER_ID`** (`0`…`N-1`) when set.
 
 ```python
+from caddysnake import cache, worker_id
+
 await cache.aset("k", b"v")
 val = await cache.aget("k")
 await cache.aappend("q", b"work")
 item = await cache.apop("q", timeout=5.0)
+cache.sadd("group:room", f"worker:{worker_id()}".encode())
+msg = cache.subscribe("events", timeout=10.0)
 ```
 
 :::note

--- a/env_file.go
+++ b/env_file.go
@@ -209,7 +209,7 @@ func buildWorkerEnv(base []string, fileVars, inlineVars map[string]string, extra
 	return envMapToSlice(merged)
 }
 
-func workerInternalEnv(iface, cacheAddr string) []string {
+func workerInternalEnv(iface, cacheAddr, workerID string) []string {
 	extra := []string{"PYTHONUNBUFFERED=1"}
 	if cacheAddr != "" {
 		extra = append(extra,
@@ -217,6 +217,9 @@ func workerInternalEnv(iface, cacheAddr string) []string {
 			EnvCaddysnakeWorkerInterface+"="+iface,
 			EnvCaddysnakeCacheTimeoutSeconds+"="+strconv.Itoa(DefaultCacheClientTimeoutSec),
 		)
+		if workerID != "" {
+			extra = append(extra, EnvCaddysnakeWorkerID+"="+workerID)
+		}
 	}
 	return extra
 }

--- a/env_file_test.go
+++ b/env_file_test.go
@@ -89,6 +89,25 @@ func TestBuildWorkerEnv_Precedence(t *testing.T) {
 	}
 }
 
+func TestWorkerInternalEnv_IncludesWorkerID(t *testing.T) {
+	env := workerInternalEnv("wsgi", "unix://cache.sock", "2")
+	m := parseEnvSlice(env)
+	if m[EnvCaddysnakeWorkerID] != "2" {
+		t.Errorf("CADDYSNAKE_WORKER_ID = %q, want 2", m[EnvCaddysnakeWorkerID])
+	}
+	if m[EnvCaddysnakeWorkerInterface] != "wsgi" {
+		t.Errorf("interface = %q", m[EnvCaddysnakeWorkerInterface])
+	}
+}
+
+func TestWorkerInternalEnv_OmitsWorkerIDWhenEmpty(t *testing.T) {
+	env := workerInternalEnv("asgi", "", "")
+	m := parseEnvSlice(env)
+	if _, ok := m[EnvCaddysnakeWorkerID]; ok {
+		t.Error("expected no worker id without cache")
+	}
+}
+
 func TestResolveEnvFilePath(t *testing.T) {
 	dir := t.TempDir()
 	rel := filepath.Join("configs", "app.env")

--- a/renovate.json
+++ b/renovate.json
@@ -3,18 +3,13 @@
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
-    ":semanticCommits"
+    ":semanticCommits",
+    "group:all"
   ],
+  "separateMajorMinor": false,
   "schedule": ["before 6am on Monday"],
   "labels": ["dependencies"],
   "packageRules": [
-    {
-      "description": "Group security patches",
-      "matchUpdateTypes": ["patch"],
-      "matchCategories": ["security"],
-      "groupName": "security-patches",
-      "automerge": false
-    },
     {
       "description": "Go module updates need review",
       "matchManagers": ["gomod"],

--- a/tests/simple_cache/main.py
+++ b/tests/simple_cache/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from urllib.parse import parse_qs
 
-from caddysnake import cache
+from caddysnake import cache, worker_id
 
 
 def _wsgi_read_body(environ, max_len: int = 1 << 20) -> bytes:
@@ -20,9 +20,15 @@ def _wsgi_read_body(environ, max_len: int = 1 << 20) -> bytes:
     return environ["wsgi.input"].read(n)
 
 
+def _qs(environ) -> dict[str, list[str]]:
+    raw = environ.get("QUERY_STRING") or ""
+    return parse_qs(raw)
+
+
 def wsgi_app(environ, start_response):
     path = environ.get("PATH_INFO") or "/"
     method = (environ.get("REQUEST_METHOD") or "GET").upper()
+    qs = _qs(environ)
 
     def respond(status: int, body: bytes, ctype: str = "text/plain") -> list[bytes]:
         reason = {200: "OK", 404: "Not Found", 500: "Internal Server Error"}.get(status, "OK")
@@ -44,6 +50,53 @@ def wsgi_app(environ, start_response):
     if path == "/share/append" and method == "POST":
         cache.append("q", _wsgi_read_body(environ))
         return respond(200, b"ok")
+
+    if path == "/share/worker-id" and method == "GET":
+        wid = worker_id()
+        return respond(200, str(wid if wid is not None else -1).encode())
+
+    if path == "/share/sadd" and method == "POST":
+        key = (qs.get("k", ["grp"])[0]).encode()
+        cache.sadd(key, _wsgi_read_body(environ))
+        return respond(200, b"ok")
+
+    if path == "/share/srem" and method == "POST":
+        key = (qs.get("k", ["grp"])[0]).encode()
+        n = cache.srem(key, _wsgi_read_body(environ))
+        return respond(200, str(n).encode())
+
+    if path == "/share/smembers" and method == "GET":
+        key = (qs.get("k", ["grp"])[0]).encode()
+        members = cache.smembers(key)
+        payload = json.dumps([m.decode("latin1") for m in members]).encode()
+        return respond(200, payload, "application/json")
+
+    if path == "/share/setnx" and method == "POST":
+        key = (qs.get("k", ["lock"])[0]).encode()
+        ttl_raw = qs.get("ttl", [""])[0]
+        body = _wsgi_read_body(environ)
+        ok = cache.setnx(key, body) if ttl_raw == "" else cache.setnx(key, body, ttl=int(ttl_raw))
+        return respond(200, b"1" if ok else b"0")
+
+    if path == "/share/keys" and method == "GET":
+        prefix = (qs.get("prefix", [""])[0]).encode()
+        limit = int(qs.get("limit", ["1000"])[0])
+        keys = cache.keys(prefix, limit=limit)
+        payload = json.dumps([k.decode("latin1") for k in keys]).encode()
+        return respond(200, payload, "application/json")
+
+    if path == "/share/publish" and method == "POST":
+        ch = (qs.get("ch", ["events"])[0]).encode()
+        n = cache.publish(ch, _wsgi_read_body(environ))
+        return respond(200, str(n).encode())
+
+    if path == "/share/subscribe" and method == "GET":
+        ch = (qs.get("ch", ["events"])[0]).encode()
+        tout = float(qs.get("t", ["25"])[0])
+        msg = cache.subscribe(ch, timeout=tout)
+        if msg is None:
+            return respond(200, b"nil")
+        return respond(200, msg, "application/octet-stream")
 
     return respond(404, b"not found")
 
@@ -123,6 +176,18 @@ async def asgi_app(scope, receive, send):
             await send_resp(200, v)
         return
 
+    if path == "/asgi/worker-id" and method == "GET":
+        wid = worker_id()
+        await send_resp(200, str(wid if wid is not None else -1).encode())
+        return
+
+    if path == "/asgi/publish" and method == "POST":
+        ch = (qs.get("ch", ["events"])[0]).encode()
+        body = await read_body()
+        n = await cache.apublish(ch, body)
+        await send_resp(200, str(n).encode())
+        return
+
     await send_resp(404, b"not found")
 
 
@@ -163,5 +228,9 @@ def application(scope, protocol):
         key = (qs.get("k", ["eq"])[0]).encode()
         cache.append(key, protocol.read_body())
         resp(200, b"ok")
+        return
+    if path == "/esgi/worker-id" and method == "GET":
+        wid = worker_id()
+        resp(200, str(wid if wid is not None else -1).encode())
         return
     resp(404, b"not found")

--- a/tests/simple_cache/main_test.py
+++ b/tests/simple_cache/main_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
 
@@ -30,6 +31,135 @@ def test_wsgi_cross_worker_blocking_pop():
     th.join(timeout=135)
     assert not th.is_alive()
     assert out == [b"cross-worker"]
+
+
+def test_cross_worker_set_add_members():
+    requests.post(f"{BASE_URL}/share/sadd?k=itgrp", data=b"w0", timeout=10).raise_for_status()
+    requests.post(f"{BASE_URL}/share/sadd?k=itgrp", data=b"w1", timeout=10).raise_for_status()
+    got = requests.get(f"{BASE_URL}/share/smembers?k=itgrp", timeout=10)
+    assert got.status_code == 200
+    assert set(got.json()) == {"w0", "w1"}
+
+
+def test_cross_worker_set_remove():
+    requests.post(f"{BASE_URL}/share/sadd?k=rmgrp", data=b"a", timeout=10).raise_for_status()
+    requests.post(f"{BASE_URL}/share/sadd?k=rmgrp", data=b"b", timeout=10).raise_for_status()
+    requests.post(f"{BASE_URL}/share/srem?k=rmgrp", data=b"a", timeout=10).raise_for_status()
+    got = requests.get(f"{BASE_URL}/share/smembers?k=rmgrp", timeout=10)
+    assert got.json() == ["b"]
+
+
+def test_cross_worker_setnx_lock_single_winner():
+    key = f"lock-{time.time_ns()}"
+
+    def try_lock():
+        return requests.post(f"{BASE_URL}/share/setnx?k={key}", data=b"held", timeout=10)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = [
+            f.result().content for f in as_completed(pool.submit(try_lock) for _ in range(8))
+        ]
+
+    assert results.count(b"1") == 1
+    assert results.count(b"0") == 7
+
+
+def test_setnx_ttl_reacquire_across_workers():
+    key = f"ttl-lock-{time.time_ns()}"
+    r1 = requests.post(f"{BASE_URL}/share/setnx?k={key}&ttl=1", data=b"x", timeout=10)
+    assert r1.content == b"1"
+    r2 = requests.post(f"{BASE_URL}/share/setnx?k={key}", data=b"y", timeout=10)
+    assert r2.content == b"0"
+    time.sleep(1.2)
+    r3 = requests.post(f"{BASE_URL}/share/setnx?k={key}", data=b"z", timeout=10)
+    assert r3.content == b"1"
+
+
+def test_keys_across_workers_and_types():
+    prefix = f"it-{time.time_ns()}:"
+    requests.post(f"{BASE_URL}/asgi/set?k={prefix}scalar", data=b"v", timeout=10).raise_for_status()
+    requests.post(
+        f"{BASE_URL}/share/append?k={prefix}list", data=b"a", timeout=10
+    ).raise_for_status()
+    requests.post(f"{BASE_URL}/share/sadd?k={prefix}set", data=b"m", timeout=10).raise_for_status()
+    got = requests.get(f"{BASE_URL}/share/keys?prefix={prefix}", timeout=10)
+    assert got.status_code == 200
+    names = set(got.json())
+    assert f"{prefix}scalar" in names
+    assert f"{prefix}list" in names
+    assert f"{prefix}set" in names
+
+
+def test_keys_security_namespace_does_not_leak():
+    secret = f"secret-{time.time_ns()}:"
+    mine = f"mine-{time.time_ns()}:"
+    requests.post(f"{BASE_URL}/asgi/set?k={secret}hidden", data=b"x", timeout=10).raise_for_status()
+    requests.post(f"{BASE_URL}/asgi/set?k={mine}visible", data=b"y", timeout=10).raise_for_status()
+    got = requests.get(f"{BASE_URL}/share/keys?prefix={mine}", timeout=10)
+    names = got.json()
+    assert f"{mine}visible" in names
+    assert not any(n.startswith(secret) for n in names)
+
+
+def test_pubsub_cross_worker_delivery():
+    ch = f"ch-{time.time_ns()}"
+    out: list[bytes] = []
+
+    def sub():
+        resp = requests.get(f"{BASE_URL}/share/subscribe?ch={ch}&t=20", timeout=25)
+        out.append(resp.content)
+
+    th = threading.Thread(target=sub)
+    th.start()
+    time.sleep(0.5)
+    pub = requests.post(f"{BASE_URL}/share/publish?ch={ch}", data=b"evt", timeout=10)
+    assert pub.status_code == 200
+    assert int(pub.text) >= 1
+    th.join(timeout=25)
+    assert out == [b"evt"]
+
+
+def test_pubsub_fanout_multiple_workers():
+    ch = f"fan-{time.time_ns()}"
+    results: list[bytes] = []
+    lock = threading.Lock()
+
+    def sub():
+        resp = requests.get(f"{BASE_URL}/share/subscribe?ch={ch}&t=20", timeout=25)
+        with lock:
+            results.append(resp.content)
+
+    threads = [threading.Thread(target=sub) for _ in range(2)]
+    for t in threads:
+        t.start()
+    time.sleep(0.5)
+    pub = requests.post(f"{BASE_URL}/share/publish?ch={ch}", data=b"fanout", timeout=10)
+    assert int(pub.text) == 2
+    for t in threads:
+        t.join(timeout=25)
+    assert sorted(results) == [b"fanout", b"fanout"]
+
+
+def test_worker_id_unique_and_stable_per_worker():
+    ids = []
+    for _ in range(20):
+        r = requests.get(f"{BASE_URL}/share/worker-id", timeout=10)
+        assert r.status_code == 200
+        ids.append(int(r.text))
+    assert set(ids) == {0, 1}
+    r1 = requests.get(f"{BASE_URL}/share/worker-id", timeout=10)
+    r2 = requests.get(f"{BASE_URL}/share/worker-id", timeout=10)
+    # round-robin may hit different workers; each response is stable for that worker process
+    assert r1.text in {"0", "1"}
+    assert r2.text in {"0", "1"}
+
+
+def test_binary_data_through_new_apis():
+    key = f"bin-{time.time_ns()}"
+    payload = b"\x00\xff\n"
+    requests.post(f"{BASE_URL}/share/sadd?k={key}", data=payload, timeout=10).raise_for_status()
+    got = requests.get(f"{BASE_URL}/share/smembers?k={key}", timeout=10)
+    assert got.json()[0] == payload.decode("latin1")
 
 
 def test_asgi_aget_and_list():
@@ -72,6 +202,9 @@ def test_esgi_cache():
 
 if __name__ == "__main__":
     test_wsgi_cross_worker_blocking_pop()
+    test_cross_worker_set_add_members()
+    test_pubsub_cross_worker_delivery()
+    test_worker_id_unique_and_stable_per_worker()
     test_asgi_aget_and_list()
     test_esgi_cache()
     print("simple_cache integration tests passed")


### PR DESCRIPTION
## Summary
- Extend the in-process CS* cache with **set ops** (`CSSADD`/`CSSREM`/`CSSMEMBERS`), **one-shot blocking pub/sub** (`CSPUBLISH`/`CSSUBSCRIBE`), **atomic SETNX**, **prefix key listing** (`CSKEYS`, non-empty prefix required), and **`CADDYSNAKE_WORKER_ID`** (stable `0..N-1` per worker group).
- Python client: `sadd`, `srem`, `smembers`, `setnx`, `keys`, `publish`, `subscribe`, `worker_id()`, plus async wrappers and extended socket timeouts for blocking ops.
- Go shutdown wakes blocked `CSPOP`/`CSSUBSCRIBE` waiters; empty sets removed on last `SREM`.
- Integration tests in `tests/simple_cache/`; docs updated in `reference.md`, `README.md`, and `AGENTS.md` (documentation checklist for future features).

## Test plan
- [x] `go test -race -v .`
- [x] `uvx --with pytest-asyncio pytest cmd/cli/tests/test_cache.py -v`
- [x] `./tests/integration.sh simple_cache 3.13` (CI Docker)
- [x] CI workflows (Lint, Go Tests, Python Tests, Security, CodeQL)


Made with [Cursor](https://cursor.com)