### PR TITLE
Use the selected socket module on the unix:// cache path

### DIFF
--- a/cmd/cli/caddysnake/kv_cache.py
+++ b/cmd/cli/caddysnake/kv_cache.py
@@ -201,9 +201,12 @@ class Cache:
         t = _timeout_sec() if timeout is None else timeout
         if addr.startswith("unix://"):
             path = addr[7:]
-            import socket as stdsocket
-
-            sock = stdsocket.socket(stdsocket.AF_UNIX, stdsocket.SOCK_STREAM)
+            # Must use ``mod`` (gevent.socket for ESGI workers), never the stdlib
+            # socket: a blocking stdlib call here does not yield to the gevent hub,
+            # which freezes every other greenlet in the worker for the duration of
+            # the cache round-trip. gevent.socket supports AF_UNIX — the ESGI
+            # listener itself uses it (see run_esgi_server in caddysnake.py).
+            sock = mod.socket(mod.AF_UNIX, mod.SOCK_STREAM)
             sock.settimeout(t)
             try:
                 sock.connect(path)

--- a/cmd/cli/pyproject.toml
+++ b/cmd/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "caddysnake"
-version = "0.5.10"
+version = "0.5.11"
 description = "Python WSGI/ASGI server powered by Caddy"
 authors = [
     {name = "Miguel Liezun", email = "liezun.js@gmail.com"},

--- a/cmd/cli/tests/test_cache.py
+++ b/cmd/cli/tests/test_cache.py
@@ -53,12 +53,15 @@ class _FakeSock:
 
 class _FakeMod:
     AF_INET = 2
+    AF_UNIX = 1
     SOCK_STREAM = 1
     _response = b""
     last_sock: _FakeSock | None = None
+    last_args: tuple = ()
 
     @classmethod
-    def socket(cls, *_a, **_k):
+    def socket(cls, *a, **_k):
+        cls.last_args = a
         cls.last_sock = _FakeSock(cls._response)
         return cls.last_sock
 
@@ -67,6 +70,34 @@ def _patch_cache(monkeypatch):
     monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", "127.0.0.1:19999")
     monkeypatch.delenv("CADDYSNAKE_WORKER_INTERFACE", raising=False)
     monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
+
+
+def _patch_cache_unix(monkeypatch, path="/tmp/caddysnake-cache-test.sock"):
+    monkeypatch.setenv("CADDYSNAKE_CACHE_ADDR", f"unix://{path}")
+    monkeypatch.setenv("CADDYSNAKE_WORKER_INTERFACE", "esgi")
+    monkeypatch.setattr("caddysnake.kv_cache._socket_module", lambda: _FakeMod)
+
+
+def test_unix_socket_uses_the_selected_socket_module(monkeypatch):
+    # ESGI workers get gevent.socket from _socket_module(). The unix:// path must
+    # honour it: opening a blocking stdlib socket instead never yields to the gevent
+    # hub, freezing every other greenlet in the worker for the whole round-trip.
+    # unix:// is the default transport on Unix, so this is the hot path.
+    _patch_cache_unix(monkeypatch)
+    _FakeMod._response = b"$-1\r\n"
+    _FakeMod.last_args = ()
+    assert Cache().get("missing") is None
+    assert _FakeMod.last_args == (_FakeMod.AF_UNIX, _FakeMod.SOCK_STREAM)
+
+
+def test_unix_blocking_roundtrip_uses_the_selected_socket_module(monkeypatch):
+    # Same requirement for the blocking (wait) variant behind pop/subscribe, which
+    # holds the socket for up to max(_timeout_sec(), wait + 5.0) seconds.
+    _patch_cache_unix(monkeypatch)
+    _FakeMod._response = b"$-1\r\n"
+    _FakeMod.last_args = ()
+    Cache().pop("q", timeout=0.01)
+    assert _FakeMod.last_args == (_FakeMod.AF_UNIX, _FakeMod.SOCK_STREAM)
 
 
 def test_get_miss_roundtrip(monkeypatch):


### PR DESCRIPTION
## Problem

`_socket_module()` returns `gevent.socket` for ESGI workers, but `Cache._open_socket` ignored the `mod` it was handed on the `unix://` branch and imported the stdlib socket instead:

```python
if addr.startswith("unix://"):
    import socket as stdsocket                                # ← mod discarded
    sock = stdsocket.socket(stdsocket.AF_UNIX, stdsocket.SOCK_STREAM)
...
sock = mod.socket(mod.AF_INET, mod.SOCK_STREAM)               # ← TCP honours it
```

Only the TCP branch honoured `mod`. `unix://` is the default transport on Unix (TCP is the Windows fallback), so in practice **every cache op in an ESGI worker used a blocking stdlib socket**.

ESGI runs greenlets but does not monkey-patch the stdlib, so that call never yields to the hub: it freezes **every greenlet in the worker** for the whole round-trip.

## Impact

This is severe for an app whose WebSocket send path runs in the pump greenlet: a handler doing a cache round-trip starves the pump that must transmit the very frame the handler is waiting on. The RPC is then *guaranteed* to time out rather than merely at risk.

We hit this in a Django app that does WebSocket RPC to a robot: a control action from an HTTP handler deadlocked for ~44s (the app's own timeout budget), and the queued frames only flushed once the handler gave up. Robot-side latency was ~40ms; the entire delay was this freeze.

## Fix

Use `mod` on both branches. `gevent.socket` supports `AF_UNIX` — `run_esgi_server` already builds its own listener with `gevent.socket.socket(AF_UNIX, SOCK_STREAM)` (caddysnake.py), so this just makes the cache client consistent with the rest of the codebase.

## Tests

The existing cache tests only ever set a **TCP** address (`_patch_cache` → `127.0.0.1:19999`), so the `unix://` branch — the production hot path on Unix — had **no coverage**. That is why this went unnoticed.

Added coverage for both the plain and blocking round-trips. Both fail against the previous code: it bypasses the fake socket module and opens a real socket (`CacheError: cannot connect to cache unix socket ... No such file or directory`).

- `pytest cmd/cli/tests/test_cache.py` — 20 passed
- `./tests/integration.sh simple_cache 3.13` — passed (per AGENTS.md, required for shared-cache changes; exercises a real Caddy build over a real unix socket with real gevent)

## Notes

- Bumps the PyPI version to `0.5.11` per the release checklist, ready for `gh release create v0.5.11` after merge.
- No user-facing API, env var, or wire-protocol change, so no docs update.
- Related but **not** addressed here: the ESGI worker never calls `monkey.patch_all()`, so any blocking stdlib call in app code (`time.sleep`, sockets, DB drivers) still freezes the worker's hub. That is a deliberate design question, not a one-line defect — worth discussing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)