### PR TITLE
Fix Docker images: symlink python3 to image Python version

### DIFF
--- a/.github/workflows/docker-verify.yml
+++ b/.github/workflows/docker-verify.yml
@@ -34,6 +34,28 @@ jobs:
           push-image: "false"
           platforms: linux/amd64
 
+  python-symlink:
+    name: Verify python/python3 symlink
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Build image and verify interpreters
+        run: |
+          expected="${{ matrix.python-version }}"
+          docker build --build-arg PY_VERSION="$expected" -t caddy-snake:pycheck .
+          for bin in python python3; do
+            got=$(docker run --rm --entrypoint "$bin" caddy-snake:pycheck -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+            echo "$bin -> $got (expected $expected)"
+            test "$got" = "$expected"
+          done
+
   trivy:
     name: Trivy scan
     runs-on: ubuntu-24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,11 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
     add-apt-repository -y ppa:deadsnakes/ppa &&\
     apt-get update -yyqq &&\
     apt-get install -yyqq python${PY_VERSION}-venv &&\
+    # Point both python and python3 at the image Python. Ubuntu ships python3 as
+    # the system interpreter (e.g. 3.10 on 22.04); workers default to "python3",
+    # so leaving the system symlink breaks pip-installed packages (see #219).
     ln -sf /usr/bin/python${PY_VERSION} /usr/bin/python &&\
+    ln -sf /usr/bin/python${PY_VERSION} /usr/bin/python3 &&\
     wget -q https://bootstrap.pypa.io/get-pip.py &&\
     python get-pip.py &&\
     apt-get clean &&\


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#219](https://github.com/mliezun/caddy-snake/issues/219): published Docker images only symlinked `/usr/bin/python` to the deadsnakes interpreter (e.g. 3.13), while `/usr/bin/python3` stayed on Ubuntu’s system Python (3.10 on 22.04).

caddy-snake workers resolve the interpreter as `python3` by default, so apps that `pip install` packages against the image Python failed with `ModuleNotFoundError: No module named 'caddysnake'` (and other packages) when workers started under system 3.10.

## Changes

- **`Dockerfile`**: also symlink `/usr/bin/python3` → `/usr/bin/python${PY_VERSION}` (same target as `python`).
- **`.github/workflows/docker-verify.yml`**: add a matrix job that builds each image tag and asserts `python` and `python3` report the expected major.minor version.

## Test plan

- [x] Dockerfile points both `python` and `python3` at `python${PY_VERSION}`
- [ ] CI `Verify python/python3 symlink` job passes for 3.12 / 3.13 / 3.14
- [ ] After merge/publish, `docker run --rm --entrypoint python3 mliezun/caddy-snake:latest-py3.13 -c 'import sys; print(sys.version)'` shows 3.13.x
- [ ] Repro from #219 (`FROM ...:latest-py3.13` + `pip install -r requirements.txt` + `from caddysnake import cache`) no longer fails under workers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89377526-0ac9-4a44-9027-e861dc8500c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89377526-0ac9-4a44-9027-e861dc8500c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

