### PR TITLE
Bump caddysnake PyPI version to 0.5.12

### DIFF
--- a/cmd/cli/pyproject.toml
+++ b/cmd/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "caddysnake"
-version = "0.5.11"
+version = "0.5.12"
 description = "Python WSGI/ASGI server powered by Caddy"
 authors = [
     {name = "Miguel Liezun", email = "liezun.js@gmail.com"},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump the PyPI package version in `cmd/cli/pyproject.toml` from `0.5.11` to `0.5.12` ahead of tagging `v0.5.12` (per `AGENTS.md` release checklist).

## What's going into the release

* Fix Docker images so `python3` matches the image Python version (#220)
* Fix Python 3.16 asyncio deprecations in ASGI workers (#218)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89377526-0ac9-4a44-9027-e861dc8500c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89377526-0ac9-4a44-9027-e861dc8500c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

