### PR TITLE
Adversarial security review: harden env_file, cache DoS, dynamic spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ from flask import Flask
 
 app = Flask(__name__)
 
+
 @app.route("/hello-world")
 def hello():
     return "Hello world!"
@@ -207,6 +208,7 @@ curl http://localhost:9080/hello-world
 from fastapi import FastAPI
 
 app = FastAPI()
+
 
 @app.get("/hello-world")
 def hello():

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ python {
 
 Path to a dotenv-style file whose variables are loaded into each Python worker process for this `python` block. You may specify `env_file` more than once; later files override earlier ones for duplicate keys.
 
-Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory.
+Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory. Relative paths must stay under that directory after symlink resolution. Keys follow the same validation as `env_var` (reserved / `LD_*` / `DYLD_*` names rejected).
 
 ```Caddyfile
 python {
@@ -331,11 +331,11 @@ python {
 }
 ```
 
-**Precedence:** Caddy process environment → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`). Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) cannot be set from the Caddyfile.
+**Precedence:** Caddy process environment → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`). Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) and loader hijack names (`LD_*`, `DYLD_*`) cannot be set from the Caddyfile or `env_file`.
 
 ### `workers`
 
-Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`).
+Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`). Maximum: **256**.
 
 When you use **process workers** (more than one worker, or the default multi-worker layout), Caddy Snake may start an **in-process shared cache** in the Go plugin and pass connection details to each worker via environment variables (see [Shared worker cache](#shared-worker-cache)).
 
@@ -394,7 +394,7 @@ Thread workers and single-worker setups do not need this path. See the [configur
 
 You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, `venv`, `env_file`, and `env_var` **values** to dynamically load different Python apps based on the request.
 
-This is useful for multi-tenant setups where each subdomain or route serves a different application:
+This is useful for multi-tenant setups where each subdomain or route serves a different application. Only use placeholders you control (e.g. hostname labels); do not bind `working_dir` / `venv` / `env_file` to untrusted headers.
 
 ```Caddyfile
 *.example.com:9080 {

--- a/cache_server.go
+++ b/cache_server.go
@@ -1047,7 +1047,8 @@ func (s *cacheServer) handleConn(conn net.Conn) {
 			var dl *time.Time
 			if len(parts) == 3 && len(parts[2]) > 0 {
 				sec, err := strconv.ParseFloat(string(parts[2]), 64)
-				if err != nil || sec < 0 {
+				// Allow 0 (immediate) but reject NaN/Inf and cap like CSSUBSCRIBE.
+				if err != nil || math.IsNaN(sec) || math.IsInf(sec, 0) || sec < 0 || sec > maxSubscribeTimeoutSec {
 					_ = respWriteError(w, "invalid timeout")
 					return
 				}

--- a/cache_server_test.go
+++ b/cache_server_test.go
@@ -346,6 +346,25 @@ func TestCacheServer_CSPOPTimeout(t *testing.T) {
 	}
 }
 
+func TestCacheServer_CSPOPInvalidTimeout(t *testing.T) {
+	srv, err := startCacheServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	for _, bad := range []string{"inf", "nan", "-1", "301"} {
+		conn := dialCacheServer(t, srv)
+		r := bufio.NewReader(conn)
+		_, _ = io.WriteString(conn, respStringArrayCmd("CSPOP", "t", bad))
+		line := readProtoLine(t, r)
+		conn.Close()
+		if !strings.HasPrefix(line, "-") {
+			t.Fatalf("CSPOP timeout %q want error, got %q", bad, line)
+		}
+	}
+}
+
 func TestCacheServer_CSQUIT(t *testing.T) {
 	srv, err := startCacheServer()
 	if err != nil {

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -355,6 +355,9 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 	if workers <= 0 {
 		workers = runtime.GOMAXPROCS(0)
 	}
+	if workers > maxPythonWorkers {
+		workers = maxPythonWorkers
+	}
 
 	startTimeout, err := parseStartTimeout(f.StartTimeout)
 	if err != nil {

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -47,6 +47,8 @@ var caddysnake_py string
 const (
 	caddySnakeRemoteAddrHeader = "Caddy-Snake-Remote-Addr"
 	caddySnakeRemotePortHeader = "Caddy-Snake-Remote-Port"
+	// maxPythonWorkers caps process spawn at provision / per dynamic key.
+	maxPythonWorkers = 256
 )
 
 // setPythonWorkerOutboundHeaders configures the outbound request to the Python
@@ -549,6 +551,9 @@ func (m *CaddySnake) Validate() error {
 		w, err := strconv.Atoi(m.Workers)
 		if err != nil || w < 0 {
 			return fmt.Errorf("invalid workers value: %s", m.Workers)
+		}
+		if w > maxPythonWorkers {
+			return fmt.Errorf("workers value %d exceeds maximum of %d", w, maxPythonWorkers)
 		}
 	}
 	if _, err := parseStartTimeout(m.StartTimeout); err != nil {

--- a/caddysnake.py
+++ b/caddysnake.py
@@ -1424,7 +1424,7 @@ def _esgi_headers_mapping(headers_list, raw_headers: dict) -> dict:
     headers_map = {}
     for n, v in headers_list:
         k = _header_name_str(n)
-        if k in ("caddy-snake-remote-addr", "caddy-snake-remote-port"):
+        if k in ("caddy-snake-remote-addr", "caddy-snake-remote-port", "proxy"):
             continue
         val = v.decode("latin-1")
         existing = headers_map.get(k)
@@ -1924,7 +1924,12 @@ async def _handle_asgi_connection(reader, writer, app, state):
             headers_for_scope = [
                 (n, v)
                 for n, v in headers
-                if n not in (b"caddy-snake-remote-addr", b"caddy-snake-remote-port")
+                if n
+                not in (
+                    b"caddy-snake-remote-addr",
+                    b"caddy-snake-remote-port",
+                    b"proxy",
+                )
             ]
             trusted_client = _client_from_caddy_snake_headers(raw_headers)
             if trusted_client is not None:

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -606,6 +606,14 @@ func TestValidate_NegativeWorkers(t *testing.T) {
 	}
 }
 
+func TestValidate_WorkersTooLarge(t *testing.T) {
+	cs := &CaddySnake{ModuleWsgi: "main:app", Workers: "100000"}
+	err := cs.Validate()
+	if err == nil || !strings.Contains(err.Error(), "maximum") {
+		t.Fatalf("expected workers maximum error, got %v", err)
+	}
+}
+
 func TestValidate_InvalidLifespan(t *testing.T) {
 	cs := &CaddySnake{ModuleWsgi: "main:app", Lifespan: "maybe"}
 	err := cs.Validate()
@@ -970,8 +978,10 @@ func TestWriteCaddysnakePyBundle(t *testing.T) {
 
 func TestDynamicAppGetOrCreate_FactoryError(t *testing.T) {
 	factoryErr := errors.New("import failed")
+	calls := 0
 	d, _ := NewDynamicApp("main:app", "/home/test", "", nil, nil,
 		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
+			calls++
 			return nil, factoryErr
 		},
 		zap.NewNop(),
@@ -991,7 +1001,22 @@ func TestDynamicAppGetOrCreate_FactoryError(t *testing.T) {
 	if len(d.apps) != 0 {
 		t.Errorf("expected 0 apps after factory error, got %d", len(d.apps))
 	}
+	if len(d.failed) != 1 {
+		t.Errorf("expected 1 failed cache entry, got %d", len(d.failed))
+	}
 	d.mu.RUnlock()
+
+	// Negative cache: second call must not re-invoke the factory.
+	app, err = d.getOrCreateApp("key1", "main:app", "/home/test", "", nil, nil)
+	if err != factoryErr {
+		t.Errorf("expected cached factory error, got: %v", err)
+	}
+	if app != nil {
+		t.Error("expected nil app on cached error")
+	}
+	if calls != 1 {
+		t.Errorf("expected factory called once, got %d", calls)
+	}
 }
 
 func TestDynamicAppCleanup_WithErrors(t *testing.T) {

--- a/caddysnake_test.py
+++ b/caddysnake_test.py
@@ -1142,6 +1142,16 @@ class TestEsgiHelpers:
         assert "caddy-snake-remote-addr" not in m
         assert m.get("x-custom") == "a, b"
 
+    def test_headers_mapping_drops_proxy(self):
+        headers_list = [
+            (b"host", b"x"),
+            (b"proxy", b"http://evil"),
+            (b"x-custom", b"ok"),
+        ]
+        m = cs._esgi_headers_mapping(headers_list, {"host": "x", "proxy": "http://evil"})
+        assert "proxy" not in m
+        assert m.get("x-custom") == "ok"
+
     def test_build_http_scope(self):
         raw = {"host": "example.com:9443", "x-forwarded-proto": "http"}
         headers_list = [(b"host", b"example.com:9443")]

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -21,19 +21,23 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class Item(BaseModel):
     name: str
     description: str | None = None
     price: float
     tax: float | None = None
 
+
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
 
+
 @app.get("/items/{item_id}")
 def read_item(item_id: int):
     return {"item_id": item_id}
+
 
 @app.post("/items/")
 def create_item(item: Item):
@@ -83,13 +87,16 @@ from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
+
 @app.route("/")
 def hello():
     return jsonify({"message": "Hello, World!"})
 
+
 @app.route("/items/<int:item_id>")
 def get_item(item_id):
     return jsonify({"item_id": item_id})
+
 
 @app.route("/items", methods=["POST"])
 def create_item():
@@ -175,26 +182,29 @@ Django is a full-featured web framework with a built-in admin interface and ORM.
 ```python
 # mysite/settings.py
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'items',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "items",
 ]
 
 # items/models.py
 from django.db import models
+
 
 class Item(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+
 # items/views.py
 from django.http import JsonResponse
 from .models import Item
+
 
 def item_list(request):
     items = Item.objects.all()
@@ -241,7 +251,7 @@ Django Channels extends Django with WebSocket support and other async protocols.
 import os
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 application = get_asgi_application()
 ```
 
@@ -278,22 +288,26 @@ from socketio import AsyncServer
 from socketio.asgi import ASGIApp
 
 app = FastAPI()
-sio = AsyncServer(async_mode='asgi')
+sio = AsyncServer(async_mode="asgi")
 socket_app = ASGIApp(sio)
+
 
 @sio.event
 async def connect(sid, environ):
     print(f"Client connected: {sid}")
 
+
 @sio.event
 async def disconnect(sid):
     print(f"Client disconnected: {sid}")
 
+
 @sio.event
 async def message(sid, data):
-    await sio.emit('message', data, skip_sid=sid)
+    await sio.emit("message", data, skip_sid=sid)
 
-app.mount('/', socket_app)
+
+app.mount("/", socket_app)
 ```
 
 ```caddyfile
@@ -341,6 +355,7 @@ Enable hot-reloading during development so your app reloads automatically when y
 from flask import Flask
 
 app = Flask(__name__)
+
 
 @app.route("/")
 def hello():
@@ -401,6 +416,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/")
 def index():
     return {"app": "app1", "message": "Hello from App 1!"}
@@ -411,6 +427,7 @@ def index():
 from fastapi import FastAPI
 
 app = FastAPI()
+
 
 @app.get("/")
 def index():

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -121,6 +121,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/hello-world")
 def hello():
     return "Hello world!"
@@ -161,6 +162,7 @@ It's possible to enable/disable [lifespan events](https://fastapi.tiangolo.com/a
 from flask import Flask
 
 app = Flask(__name__)
+
 
 @app.route("/hello-world")
 def hello():

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -166,7 +166,7 @@ The `working_dir` directive also supports [Caddy placeholders](#dynamic-module-l
 
 Path to a dotenv-style file (for example `.env`) loaded into the Python worker environment for this `python` block. Repeat the directive to load multiple files; later files override earlier ones for duplicate keys.
 
-Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory.
+Relative paths are resolved against `working_dir` when set, otherwise against the Caddy process working directory. **Relative** `env_file` paths are confined to that directory after symlink resolution (a `.env` symlink that escapes `working_dir` is rejected). Absolute paths are trusted as configured by the operator.
 
 ```caddyfile
 python {
@@ -182,6 +182,8 @@ Supported file format:
 - Optional double or single quotes around values
 - `#` comments and blank lines
 - Optional `export KEY=VALUE` prefix
+
+Keys must match `[A-Za-z_][A-Za-z0-9_]*`. Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) and dynamic-linker / loader hijack names (`LD_*`, `DYLD_*`, including `LD_PRELOAD`) are rejected — the same rules as [`env_var`](#env_var).
 
 Changes to env files are picked up when workers are restarted or when [autoreload](#autoreload) respawns workers; env files are not watched independently.
 
@@ -201,9 +203,13 @@ python {
 }
 ```
 
-Variable names must match `[A-Za-z_][A-Za-z0-9_]*`. Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) cannot be set from the Caddyfile.
+Variable names must match `[A-Za-z_][A-Za-z0-9_]*`. Reserved names (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`) and dynamic-linker / loader hijack names (`LD_*`, `DYLD_*`) cannot be set from the Caddyfile or from `env_file`.
 
 **Environment precedence:** Caddy process env → `env_file` → `env_var` → internal worker vars (`PYTHONUNBUFFERED`, `CADDYSNAKE_*`).
+
+:::note Trust model
+Workers inherit the Caddy process environment by default. Treat the Caddy config operator and all Python apps on a handler as the same trust domain: do not put mutually untrusted tenants in one process without additional isolation. Prefer `env_file` / `env_var` for app secrets rather than relying on ambient process env alone.
+:::
 
 ### `venv`
 
@@ -222,7 +228,7 @@ The venv packages are added to the global `sys.path`, which means all Python app
 
 ### `workers`
 
-Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`).
+Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`). Maximum value: **256**.
 
 ```caddyfile
 python {
@@ -279,6 +285,10 @@ python {
 You can use [Caddy placeholders](https://caddyserver.com/docs/caddyfile/concepts#placeholders) in `module_wsgi`, `module_asgi`, `working_dir`, `venv`, `env_file`, and `env_var` values to dynamically load different Python apps based on the request.
 
 This is useful for multi-tenant setups where each subdomain or route serves a different application.
+
+:::warning Security
+Placeholders may come from Host, path, **headers**, and other request fields. Only use placeholders that you control (for example hostname labels behind a trusted TLS site). Do **not** wire `working_dir`, `venv`, `python_path`, or `env_file` to untrusted headers or query strings — absolute resolved paths are allowed except for literal `..` segments. Prefer a fixed parent directory plus a single safe label (e.g. `{http.request.host.labels.2}/`). Failed dynamic creates are negatively cached for a few seconds to limit fork/exec storms from bad keys.
+:::
 
 ```caddyfile
 *.example.com:9080 {
@@ -466,6 +476,8 @@ Each key is in one of three shapes:
 
 There is **no tenant isolation** between workers or dynamic apps on the same handler — any worker can read, delete, or enumerate keys. Use app-specific prefixes. **`CSGROUPSEND`** (atomic set fan-out) is not built in; use **`smembers`** + **`append`** in app code with known race trade-offs, or external Redis for full channel-layer semantics.
 
+Access control is **local OS identity**: Unix sockets live under a private `0700` temp directory; on Windows the cache listens on **loopback TCP** (any local process that can dial the port can use the cache). Do not treat the shared cache as a cross-tenant secret store.
+
 :::
 
 ### Wire protocol (CS* commands)
@@ -478,7 +490,7 @@ All commands are RESP2 arrays of bulk strings. Replies are bulk (`$…`), intege
 | **`CSSET`** | key value [ttl_sec] | `+OK` | Overwrites any prior type |
 | **`CSDEL`** | key | `:0` / `:1` | |
 | **`CSAPPEND`** | key chunk | `+OK` | List only; wrong type on sets |
-| **`CSPOP`** | key [timeout_sec] | bulk or `$-1` | FIFO; blocks when timeout set |
+| **`CSPOP`** | key [timeout_sec] | bulk or `$-1` | FIFO; blocks when timeout set; timeout ≤ **300** s (NaN/Inf rejected) |
 | **`CSSADD`** | key member | `:0` / `:1` | Creates set if missing |
 | **`CSSREM`** | key member | `:0` / `:1` | Deletes key when last member removed |
 | **`CSSMEMBERS`** | key | `*N` bulks | `*0` if missing (Redis-aligned) |

--- a/dynamic.go
+++ b/dynamic.go
@@ -120,6 +120,15 @@ type appCreate struct {
 	err  error
 }
 
+// failedAppCreate caches a failed factory result briefly so repeated requests
+// for a bad dynamic key do not fork/exec Python on every hit (DoS amplifier).
+type failedAppCreate struct {
+	err       error
+	expiresAt time.Time
+}
+
+const dynamicCreateFailureTTL = 5 * time.Second
+
 // DynamicApp implements AppServer by lazily importing Python apps based on
 // Caddy placeholders resolved at request time. For example, when working_dir
 // contains {host.labels.2}, each subdomain gets its own Python app instance
@@ -128,6 +137,7 @@ type DynamicApp struct {
 	mu              sync.RWMutex
 	apps            map[string]AppServer
 	inflight        map[string]*appCreate
+	failed          map[string]failedAppCreate
 	closed          bool
 	modulePattern   string
 	workingDir      string
@@ -154,6 +164,7 @@ func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns [
 	d := &DynamicApp{
 		apps:                make(map[string]AppServer),
 		inflight:            make(map[string]*appCreate),
+		failed:              make(map[string]failedAppCreate),
 		modulePattern:       modulePattern,
 		workingDir:          workingDir,
 		venvPath:            venvPath,
@@ -229,10 +240,16 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		return nil, errors.New("dynamic app shutting down")
 	}
 	app, ok := d.apps[key]
-	d.mu.RUnlock()
 	if ok {
+		d.mu.RUnlock()
 		return app, nil
 	}
+	if f, failed := d.failed[key]; failed && time.Now().Before(f.expiresAt) {
+		err := f.err
+		d.mu.RUnlock()
+		return nil, err
+	}
+	d.mu.RUnlock()
 
 	d.mu.Lock()
 	if d.closed {
@@ -243,6 +260,11 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 	if ok {
 		d.mu.Unlock()
 		return app, nil
+	}
+	if f, failed := d.failed[key]; failed && time.Now().Before(f.expiresAt) {
+		err := f.err
+		d.mu.Unlock()
+		return nil, err
 	}
 	if c, creating := d.inflight[key]; creating {
 		d.mu.Unlock()
@@ -269,6 +291,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 				delete(d.inflight, key)
 				c.app = nil
 				c.err = fmt.Errorf("panic creating dynamic app: %v", r)
+				d.failed[key] = failedAppCreate{err: c.err, expiresAt: time.Now().Add(dynamicCreateFailureTTL)}
 				close(c.done)
 				d.mu.Unlock()
 				panic(r)
@@ -293,10 +316,13 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		return nil, err
 	}
 	if err == nil {
+		delete(d.failed, key)
 		d.apps[key] = app
 		if d.autoreload && dir != "" {
 			d.startWatchingDir(dir, key)
 		}
+	} else {
+		d.failed[key] = failedAppCreate{err: err, expiresAt: time.Now().Add(dynamicCreateFailureTTL)}
 	}
 	c.app = app
 	c.err = err
@@ -415,6 +441,7 @@ func (d *DynamicApp) reloadDir(absDir string) {
 			oldApps = append(oldApps, app)
 			delete(d.apps, key)
 		}
+		delete(d.failed, key)
 	}
 
 	delete(d.dirToKeys, absDir)
@@ -487,6 +514,7 @@ func (d *DynamicApp) Cleanup() error {
 		}
 		delete(d.apps, key)
 	}
+	d.failed = make(map[string]failedAppCreate)
 	d.mu.Unlock()
 	return errors.Join(errs...)
 }

--- a/dynamic.go
+++ b/dynamic.go
@@ -191,6 +191,24 @@ func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns [
 	return d, nil
 }
 
+// pruneExpiredFailuresLocked removes expired negative-cache entries.
+// Caller must hold d.mu for writing.
+func (d *DynamicApp) pruneExpiredFailuresLocked(now time.Time) {
+	for key, f := range d.failed {
+		if !now.Before(f.expiresAt) {
+			delete(d.failed, key)
+		}
+	}
+}
+
+// rememberFailedCreateLocked records a failed create and drops expired entries.
+// Caller must hold d.mu for writing.
+func (d *DynamicApp) rememberFailedCreateLocked(key string, err error) {
+	now := time.Now()
+	d.pruneExpiredFailuresLocked(now)
+	d.failed[key] = failedAppCreate{err: err, expiresAt: now.Add(dynamicCreateFailureTTL)}
+}
+
 // resolve uses the Caddy replacer from the request context to substitute
 // placeholders in the module pattern, working directory, venv path, env files,
 // and env_var values.
@@ -256,6 +274,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		d.mu.Unlock()
 		return nil, errors.New("dynamic app shutting down")
 	}
+	d.pruneExpiredFailuresLocked(time.Now())
 	app, ok = d.apps[key]
 	if ok {
 		d.mu.Unlock()
@@ -291,7 +310,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 				delete(d.inflight, key)
 				c.app = nil
 				c.err = fmt.Errorf("panic creating dynamic app: %v", r)
-				d.failed[key] = failedAppCreate{err: c.err, expiresAt: time.Now().Add(dynamicCreateFailureTTL)}
+				d.rememberFailedCreateLocked(key, c.err)
 				close(c.done)
 				d.mu.Unlock()
 				panic(r)
@@ -322,7 +341,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 			d.startWatchingDir(dir, key)
 		}
 	} else {
-		d.failed[key] = failedAppCreate{err: err, expiresAt: time.Now().Add(dynamicCreateFailureTTL)}
+		d.rememberFailedCreateLocked(key, err)
 	}
 	c.app = app
 	c.err = err

--- a/env_file.go
+++ b/env_file.go
@@ -12,12 +12,36 @@ import (
 
 var validEnvVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// dangerousEnvVarNames are loader / dynamic-linker variables that must not be
+// set via env_file or env_var (arbitrary code execution / library hijack).
+var dangerousEnvVarNames = map[string]struct{}{
+	"LD_PRELOAD":                 {},
+	"LD_LIBRARY_PATH":            {},
+	"LD_AUDIT":                   {},
+	"LD_DYNAMIC_WEAK":            {},
+	"LD_ORIGIN_PATH":             {},
+	"LD_USE_LOAD_BIAS":           {},
+	"DYLD_INSERT_LIBRARIES":      {},
+	"DYLD_LIBRARY_PATH":          {},
+	"DYLD_FORCE_FLAT_NAMESPACE":  {},
+	"DYLD_FALLBACK_LIBRARY_PATH": {},
+	"DYLD_IMAGE_SUFFIX":          {},
+	"DYLD_PRINT_TO_FILE":         {},
+}
+
 func validateEnvVarName(name string) error {
 	if !validEnvVarName.MatchString(name) {
 		return fmt.Errorf("must match [A-Za-z_][A-Za-z0-9_]*")
 	}
 	if name == "PYTHONUNBUFFERED" || strings.HasPrefix(name, "CADDYSNAKE_") {
 		return fmt.Errorf("reserved environment variable name")
+	}
+	if _, bad := dangerousEnvVarNames[name]; bad {
+		return fmt.Errorf("disallowed environment variable name")
+	}
+	// Catch other LD_* / DYLD_* variants without enumerating every platform quirk.
+	if strings.HasPrefix(name, "LD_") || strings.HasPrefix(name, "DYLD_") {
+		return fmt.Errorf("disallowed environment variable name")
 	}
 	return nil
 }
@@ -76,9 +100,10 @@ func resolveEnvFilePath(workingDir, envFile string) (string, error) {
 	if hasDotDotSegment(envFile) {
 		return "", fmt.Errorf("env_file path contains path traversal: %q", envFile)
 	}
+	relative := !filepath.IsAbs(envFile)
 	path := envFile
-	if !filepath.IsAbs(path) {
-		base := workingDir
+	base := workingDir
+	if relative {
 		if base == "" {
 			var err error
 			base, err = os.Getwd()
@@ -92,7 +117,39 @@ func resolveEnvFilePath(workingDir, envFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid env_file path: %w", err)
 	}
+	// Relative env_file paths must stay under the working directory even when
+	// the leaf is a symlink (same containment idea as tls.permission.python_dir).
+	if relative && base != "" {
+		if err := ensureEnvFileInsideWorkingDir(base, abs); err != nil {
+			return "", err
+		}
+	}
 	return abs, nil
+}
+
+func ensureEnvFileInsideWorkingDir(workingDir, envFileAbs string) error {
+	baseAbs, err := filepath.Abs(workingDir)
+	if err != nil {
+		return fmt.Errorf("resolve env_file working_dir: %w", err)
+	}
+	baseEval, err := filepath.EvalSymlinks(baseAbs)
+	if err != nil {
+		// working_dir may not exist yet at validate time; fall back to cleaned abs.
+		baseEval = filepath.Clean(baseAbs)
+	} else {
+		baseEval = filepath.Clean(baseEval)
+	}
+	fileEval, err := filepath.EvalSymlinks(envFileAbs)
+	if err != nil {
+		// Missing file: still reject when the unresolved path escapes the base.
+		fileEval = filepath.Clean(envFileAbs)
+	} else {
+		fileEval = filepath.Clean(fileEval)
+	}
+	if !pythonDirTLSPermInsideRoot(baseEval, fileEval) {
+		return fmt.Errorf("env_file %q resolves outside working_dir %q", envFileAbs, workingDir)
+	}
+	return nil
 }
 
 func parseEnvFile(path string) (map[string]string, error) {
@@ -119,6 +176,9 @@ func parseEnvFile(path string) (map[string]string, error) {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			return nil, fmt.Errorf("%s:%d: empty variable name", path, lineNum)
+		}
+		if err := validateEnvVarName(key); err != nil {
+			return nil, fmt.Errorf("%s:%d: invalid variable name %q: %w", path, lineNum, key, err)
 		}
 		value = strings.TrimSpace(value)
 		if len(value) >= 2 {

--- a/env_file_test.go
+++ b/env_file_test.go
@@ -160,6 +160,75 @@ func TestValidateEnvVarName(t *testing.T) {
 	if err := validateEnvVarName("PYTHONUNBUFFERED"); err == nil {
 		t.Error("expected error for reserved name")
 	}
+	if err := validateEnvVarName("LD_PRELOAD"); err == nil {
+		t.Error("expected error for LD_PRELOAD")
+	}
+	if err := validateEnvVarName("LD_LIBRARY_PATH"); err == nil {
+		t.Error("expected error for LD_LIBRARY_PATH")
+	}
+	if err := validateEnvVarName("DYLD_INSERT_LIBRARIES"); err == nil {
+		t.Error("expected error for DYLD_INSERT_LIBRARIES")
+	}
+}
+
+func TestParseEnvFile_RejectsDangerousKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte("LD_PRELOAD=/tmp/evil.so\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := parseEnvFile(path)
+	if err == nil || !strings.Contains(err.Error(), "LD_PRELOAD") {
+		t.Fatalf("expected LD_PRELOAD rejection, got %v", err)
+	}
+}
+
+func TestParseEnvFile_RejectsReservedKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte("CADDYSNAKE_CACHE_ADDR=evil\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := parseEnvFile(path)
+	if err == nil || !strings.Contains(err.Error(), "CADDYSNAKE_CACHE_ADDR") {
+		t.Fatalf("expected reserved name rejection, got %v", err)
+	}
+}
+
+func TestResolveEnvFilePath_SymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	working := filepath.Join(root, "tenant")
+	outside := filepath.Join(root, "secret.env")
+	if err := os.Mkdir(working, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("SECRET=1\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(working, ".env")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveEnvFilePath(working, ".env")
+	if err == nil || !strings.Contains(err.Error(), "outside working_dir") {
+		t.Fatalf("expected symlink escape rejection, got %v", err)
+	}
+}
+
+func TestResolveEnvFilePath_RelativeInsideWorkingDir(t *testing.T) {
+	working := t.TempDir()
+	path := filepath.Join(working, ".env")
+	if err := os.WriteFile(path, []byte("OK=1\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	abs, err := resolveEnvFilePath(working, ".env")
+	if err != nil {
+		t.Fatalf("resolveEnvFilePath: %v", err)
+	}
+	want, _ := filepath.Abs(path)
+	if abs != want {
+		t.Errorf("got %q, want %q", abs, want)
+	}
 }
 
 func TestUnmarshalCaddyfile_EnvFile(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adversarial review of the caddy-snake attack surface (worker IPC, shared cache, env/config, dynamic apps, embed extractors). This PR remediates the highest-confidence, low-breakage issues and documents residual trust-model risks.

## Findings fixed in this PR

| Severity | Issue | Fix |
| --- | --- | --- |
| **Critical** | `env_file` accepted `LD_PRELOAD` / `LD_*` / `DYLD_*` (and reserved `CADDYSNAKE_*`) while `env_var` did not | Same key validation for dotenv keys; reject linker/loader hijack names |
| **High** | Relative `env_file` followed symlinks out of `working_dir` (cross-tenant secret read) | After `EvalSymlinks`, require path stays under `working_dir` |
| **Medium** | `CSPOP` accepted `Inf` / huge timeouts (unlike `CSSUBSCRIBE`) | Cap at 300s; reject NaN/Inf |
| **Medium** | `workers 100000` allowed at Validate | Cap at **256** |
| **Medium** | Failed `DynamicApp` creates not cached → fork/exec storm on bad keys | 5s negative cache |
| **Low** | ASGI/ESGI passed `Proxy` header (WSGI already strips httpoxy) | Strip `proxy` for ASGI/ESGI |

## Residual risks (by design / larger changes)

These remain intentional trust boundaries or need follow-up design work:

1. **Shared cache has no auth / no tenant namespace** — any same-UID worker (and any local dialer on Windows loopback TCP) can `CSKEYS`/`CSGET`/`CSDEL` everything. Docs updated; true fix needs enforced prefixes or tokens.
2. **Workers inherit full `os.Environ()`** — multi-tenant handlers share Caddy process secrets. Scrubbing/allowlisting is a behavior break; documented trust model.
3. **Dynamic placeholders allow absolute `working_dir` / `venv`** — only `..` is blocked. Header-driven placeholders can still be RCE if misconfigured. Warning added in docs; a mandatory root jail would be a new config surface.
4. **Autoreload** — write access to watched trees ⇒ live code swap (dev feature).
5. **Embed tar extract** — symlink-then-write without `O_NOFOLLOW` is a supply-chain footgun for malicious standalone archives (not a remote path).

## Test plan

- [x] `go test -race .` (includes new env_file / CSPOP / workers / DynamicApp tests)
- [x] `pytest caddysnake_test.py` (includes ASGI/ESGI proxy strip)
- [ ] CI Lint / Go Tests / Python Tests on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c30735f8-9337-436a-8f10-b01b3bfd5f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c30735f8-9337-436a-8f10-b01b3bfd5f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

