### PR TITLE
Improve code quality: DynamicApp caps, worker hardening, docs drift

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,3 @@ issues:
         - errcheck
         - gosimple
         - staticcheck
-    - path: cache_server\.go
-      linters:
-        - unused

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To make it easier to get started you can also grab one of the precompiled binari
 ## Features
 
 - **WSGI, ASGI & ESGI** — serve WSGI and ASGI frameworks, plus [ESGI](https://github.com/mliezun/esgi) apps (blocking `application(scope, protocol)` per connection)
-- **Multi-worker** — process-based (default) or thread-based workers for concurrent request handling
+- **Multi-worker** — process-based workers for concurrent request handling
 - **Shared worker cache** — optional key/value store in the Caddy (Go) process so Python **process** workers can share state via a small RESP client; on Linux/macOS the transport is a **Unix domain socket** (`unix://…` in `CADDYSNAKE_CACHE_ADDR`), on Windows it uses **loopback TCP**
 - **Auto-reload** — watches `.py` files and hot-reloads your app on changes during development
 - **Dynamic module loading** — use Caddy placeholders to load different apps per subdomain or route
@@ -62,7 +62,7 @@ This starts a server on port `9080` serving your app. See `./caddy python-server
 --domain <example.com>    Enable HTTPS with automatic certificates
 --listen <addr>           Custom listen address (default: :9080)
 --workers <count>         Number of worker processes (default: CPU count)
---python-path <path>      Path to Python executable (default: embedded Python)
+--python-path <path>      Path to Python executable (default: system/venv python; embedded in standalone builds)
 --working-dir <path>      Working directory for the Python app
 --venv <path>             Path to virtual environment
 --env-file <path>         Dotenv file for worker env (repeatable)
@@ -287,9 +287,9 @@ Selects how the Python worker schedules work at the gateway boundary:
 
 ### `venv`
 
-Path to a Python virtual environment. Behind the scenes, this appends `venv/lib/python3.x/site-packages` to `sys.path` so installed packages are available to your app.
+Path to a Python virtual environment. Each Python **worker process** adds that venv’s `site-packages` to its own `sys.path`, so installed packages are available to your app.
 
-> **Note:** The venv packages are added to the global `sys.path`, which means all Python apps served by Caddy share the same packages.
+> **Note:** Workers are separate processes: a venv configured for one `python` handler (or one dynamic tenant) does not leak packages into other workers’ interpreters.
 
 ### `working_dir`
 
@@ -337,7 +337,7 @@ python {
 
 Number of worker processes to spawn. Defaults to the number of CPUs (`GOMAXPROCS`).
 
-When you use **process workers** (more than one worker, or the default multi-worker layout), Caddy Snake may start an **in-process shared cache** in the Go plugin and pass connection details to each worker via environment variables (see [Shared worker cache](#shared-worker-cache)).
+When the `python` handler is provisioned, Caddy Snake starts an **in-process shared cache** in the Go plugin and passes connection details to each worker via environment variables (see [Shared worker cache](#shared-worker-cache)).
 
 ### `start_timeout`
 
@@ -405,7 +405,7 @@ This is useful for multi-tenant setups where each subdomain or route serves a di
 }
 ```
 
-In this example, a request to `app1.example.com` loads the app from the `app1/` directory, `app2.example.com` loads from `app2/`, and so on. Apps are lazily created on first request and cached for subsequent requests.
+In this example, a request to `app1.example.com` loads the app from the `app1/` directory, `app2.example.com` loads from `app2/`, and so on. Apps are lazily created on first request and cached for subsequent requests (default cap: 128 apps, 30m idle TTL; see `CADDYSNAKE_MAX_DYNAMIC_APPS` / `CADDYSNAKE_DYNAMIC_APP_IDLE_TTL`).
 
 ---
 
@@ -517,12 +517,12 @@ Caddy Snake serves **~60% more requests/sec than Gunicorn** for Flask, **~51% mo
 
 ## Platform support
 
-| Platform       | Workers runtime   | Notes                                    |
-|----------------|-------------------|------------------------------------------|
-| Linux (x86_64) | process, thread   | Primary platform, full support           |
-| Linux (arm64)  | process, thread   | Full support                             |
-| macOS          | process, thread   | Full support                             |
-| Windows        | thread only       | Process workers not supported on Windows |
+| Platform       | Workers | Notes                          |
+|----------------|---------|--------------------------------|
+| Linux (x86_64) | process | Primary platform, full support |
+| Linux (arm64)  | process | Full support                   |
+| macOS          | process | Full support                   |
+| Windows        | process | Loopback TCP instead of Unix sockets |
 
 **Python versions:** 3.12, 3.13, 3.13-nogil (free-threaded), 3.14, 3.14-nogil (free-threaded)
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ from flask import Flask
 
 app = Flask(__name__)
 
+
 @app.route("/hello-world")
 def hello():
     return "Hello world!"
@@ -207,6 +208,7 @@ curl http://localhost:9080/hello-world
 from fastapi import FastAPI
 
 app = FastAPI()
+
 
 @app.get("/hello-world")
 def hello():

--- a/autoreload.go
+++ b/autoreload.go
@@ -72,7 +72,7 @@ type AutoreloadableApp struct {
 	stopCh              chan struct{}
 	logger              *zap.Logger
 	workingDir          string
-	exitOnReloadFailure func(code int) // if set, process exits on reload failure instead of serving 500
+	exitOnReloadFailure func(code int) // if set, process exits on reload failure instead of serving 503
 }
 
 // NewAutoreloadableApp creates an AutoreloadableApp that wraps the given app and

--- a/cache_server.go
+++ b/cache_server.go
@@ -75,9 +75,8 @@ func (e *cacheEntry) expired(now time.Time) bool {
 type cacheStore struct {
 	mu      sync.Mutex
 	data    map[string]*cacheEntry
-	conds   map[string]*sync.Cond // lazily created; all use &mu
+	conds   map[string]*sync.Cond // lazily created; all use &mu (Wait unlocks while blocked)
 	closing bool
-	keyCap  int //nolint:unused // reserved for future max-keys enforcement
 }
 
 func newCacheStore() *cacheStore {
@@ -748,10 +747,6 @@ func respWriteBulk(w *bufio.Writer, b []byte) error {
 		return err
 	}
 	return w.Flush()
-}
-
-func respWriteBulkString(w *bufio.Writer, s string) error {
-	return respWriteBulk(w, []byte(s))
 }
 
 func respWriteArrayHeader(w *bufio.Writer, n int) error {

--- a/cache_server_test.go
+++ b/cache_server_test.go
@@ -151,6 +151,35 @@ func TestCacheStore_PopBlocksUntilAppend(t *testing.T) {
 	}
 }
 
+func TestCacheStore_GetSucceedsWhilePopBlocked(t *testing.T) {
+	// sync.Cond.Wait unlocks the store mutex while blocked, so other keys remain usable.
+	s := newCacheStore()
+	_ = s.Append([]byte("q"), []byte("item"))
+	_, _ = s.Pop([]byte("q"), nil)
+	_ = s.Set([]byte("other"), []byte("value"), 0)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		_, _ = s.Pop([]byte("q"), nil)
+		close(done)
+	}()
+	<-started
+	time.Sleep(20 * time.Millisecond)
+
+	got, _, _, kind, ok := s.Get([]byte("other"))
+	if !ok || kind != entryScalar || string(got) != "value" {
+		t.Fatalf("expected Get to succeed while Pop waits, ok=%v kind=%v got=%q", ok, kind, got)
+	}
+	_ = s.Append([]byte("q"), []byte("unblock"))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pop did not unblock")
+	}
+}
+
 func TestCacheStore_DeleteUnblocksPop(t *testing.T) {
 	s := newCacheStore()
 	_ = s.Append([]byte("k"), []byte("a"))

--- a/caddysnake.go
+++ b/caddysnake.go
@@ -349,7 +349,14 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 		}
 	}()
 
-	workers, _ := strconv.Atoi(f.Workers)
+	workers := 0
+	if f.Workers != "" {
+		var parseErr error
+		workers, parseErr = strconv.Atoi(f.Workers)
+		if parseErr != nil || workers < 0 {
+			return fmt.Errorf("invalid workers value %q: must be a non-negative integer", f.Workers)
+		}
+	}
 	if workers <= 0 {
 		workers = runtime.GOMAXPROCS(0)
 	}
@@ -377,36 +384,32 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 	envFiles := cloneEnvFiles(f.EnvFiles)
 	envVars := cloneEnvVars(f.EnvVars)
 
-	if f.ModuleWsgi != "" {
-		rt := effectivePythonRuntime("wsgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-		if err != nil {
-			return err
-		}
-		if f.Lifespan != "" {
+	iface, module, err := f.pythonInterfaceAndModule()
+	if err != nil {
+		return err
+	}
+	lifespan := ""
+	if iface == "asgi" {
+		lifespan = f.Lifespan
+	} else if f.Lifespan != "" {
+		if iface == "wsgi" {
 			f.logger.Warn("lifespan attribute is ignored in WSGI mode", zap.String("lifespan", f.Lifespan))
-		}
-		f.logger.Info("serving wsgi app", zap.String("module_wsgi", f.ModuleWsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
-	} else if f.ModuleAsgi != "" {
-		rt := effectivePythonRuntime("asgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-		if err != nil {
-			return err
-		}
-		f.logger.Info("serving asgi app", zap.String("module_asgi", f.ModuleAsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
-	} else if f.ModuleEsgi != "" {
-		rt := effectivePythonRuntime("esgi", f.Runtime)
-		f.app, err = NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-		if err != nil {
-			return err
-		}
-		if f.Lifespan != "" {
+		} else {
 			f.logger.Warn("lifespan is for ASGI only; ignored in ESGI mode", zap.String("lifespan", f.Lifespan))
 		}
-		f.logger.Info("serving esgi app", zap.String("module_esgi", f.ModuleEsgi), zap.String("working_dir", f.WorkingDir), zap.String("venv_path", f.VenvPath), zap.String("python", pythonBin), zap.String("runtime", rt))
-	} else {
-		return errors.New("a wsgi, asgi, or esgi app must be specified")
 	}
+	rt := effectivePythonRuntime(iface, f.Runtime)
+	f.app, err = NewPythonWorkerGroup(iface, module, f.WorkingDir, f.VenvPath, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
+	if err != nil {
+		return err
+	}
+	f.logger.Info("serving "+iface+" app",
+		zap.String("module_"+iface, module),
+		zap.String("working_dir", f.WorkingDir),
+		zap.String("venv_path", f.VenvPath),
+		zap.String("python", pythonBin),
+		zap.String("runtime", rt),
+	)
 
 	if f.Autoreload == "on" {
 		watchDir := f.WorkingDir
@@ -418,22 +421,8 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 			return fmt.Errorf("autoreload: %w", absErr)
 		}
 
-		var factory func() (AppServer, error)
-		if f.ModuleWsgi != "" {
-			rt := effectivePythonRuntime("wsgi", f.Runtime)
-			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("wsgi", f.ModuleWsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-			}
-		} else if f.ModuleAsgi != "" {
-			rt := effectivePythonRuntime("asgi", f.Runtime)
-			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("asgi", f.ModuleAsgi, f.WorkingDir, f.VenvPath, f.Lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-			}
-		} else {
-			rt := effectivePythonRuntime("esgi", f.Runtime)
-			factory = func() (AppServer, error) {
-				return NewPythonWorkerGroup("esgi", f.ModuleEsgi, f.WorkingDir, f.VenvPath, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
-			}
+		factory := func() (AppServer, error) {
+			return NewPythonWorkerGroup(iface, module, f.WorkingDir, f.VenvPath, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, f.logger)
 		}
 
 		// Keep Caddy running on reload errors; failed app serves 503 until recovery.
@@ -447,6 +436,20 @@ func (f *CaddySnake) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+// pythonInterfaceAndModule returns the configured worker interface and module path.
+func (f *CaddySnake) pythonInterfaceAndModule() (iface, module string, err error) {
+	switch {
+	case f.ModuleWsgi != "":
+		return "wsgi", f.ModuleWsgi, nil
+	case f.ModuleAsgi != "":
+		return "asgi", f.ModuleAsgi, nil
+	case f.ModuleEsgi != "":
+		return "esgi", f.ModuleEsgi, nil
+	default:
+		return "", "", errors.New("a wsgi, asgi, or esgi app must be specified")
+	}
+}
+
 // provisionDynamic sets up the module in dynamic mode where Caddy placeholders
 // in module_wsgi/module_asgi/module_esgi, working_dir, or venv are resolved per-request.
 func (f *CaddySnake) provisionDynamic(workers int, cacheAddr string, startTimeout time.Duration) error {
@@ -456,65 +459,34 @@ func (f *CaddySnake) provisionDynamic(workers int, cacheAddr string, startTimeou
 	envVarPatterns := cloneEnvVars(f.EnvVars)
 	logger := f.logger
 
-	if f.ModuleWsgi != "" {
-		lifespan := f.Lifespan
-		rt := effectivePythonRuntime("wsgi", f.Runtime)
-		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
-			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("wsgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, logger)
-		}
-		var err error
-		f.app, err = NewDynamicApp(f.ModuleWsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
-		if err != nil {
-			return err
-		}
-		if f.Lifespan != "" {
-			f.logger.Warn("lifespan attribute is ignored in WSGI mode", zap.String("lifespan", f.Lifespan))
-		}
-		f.logger.Info("serving dynamic wsgi app",
-			zap.String("module_wsgi", f.ModuleWsgi),
-			zap.String("working_dir", f.WorkingDir),
-			zap.String("venv_path", f.VenvPath),
-		)
-	} else if f.ModuleAsgi != "" {
-		lifespan := f.Lifespan
-		rt := effectivePythonRuntime("asgi", f.Runtime)
-		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
-			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("asgi", module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, logger)
-		}
-		var err error
-		f.app, err = NewDynamicApp(f.ModuleAsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
-		if err != nil {
-			return err
-		}
-		f.logger.Info("serving dynamic asgi app",
-			zap.String("module_asgi", f.ModuleAsgi),
-			zap.String("working_dir", f.WorkingDir),
-			zap.String("venv_path", f.VenvPath),
-		)
-	} else if f.ModuleEsgi != "" {
-		rt := effectivePythonRuntime("esgi", f.Runtime)
-		factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
-			pythonBin := resolvePythonInterpreter(pythonPath, venv)
-			return NewPythonWorkerGroup("esgi", module, dir, venv, "", rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, logger)
-		}
-		var err error
-		f.app, err = NewDynamicApp(f.ModuleEsgi, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
-		if err != nil {
-			return err
-		}
-		if f.Lifespan != "" {
-			f.logger.Warn("lifespan is for ASGI only; ignored in dynamic ESGI mode", zap.String("lifespan", f.Lifespan))
-		}
-		f.logger.Info("serving dynamic esgi app",
-			zap.String("module_esgi", f.ModuleEsgi),
-			zap.String("working_dir", f.WorkingDir),
-			zap.String("venv_path", f.VenvPath),
-		)
-	} else {
+	iface, modulePattern, err := f.pythonInterfaceAndModule()
+	if err != nil {
 		return errors.New("a wsgi, asgi, or esgi app must be specified for dynamic mode")
 	}
+	lifespan := ""
+	if iface == "asgi" {
+		lifespan = f.Lifespan
+	} else if f.Lifespan != "" {
+		if iface == "wsgi" {
+			f.logger.Warn("lifespan attribute is ignored in WSGI mode", zap.String("lifespan", f.Lifespan))
+		} else {
+			f.logger.Warn("lifespan is for ASGI only; ignored in dynamic ESGI mode", zap.String("lifespan", f.Lifespan))
+		}
+	}
+	rt := effectivePythonRuntime(iface, f.Runtime)
+	factory := func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
+		pythonBin := resolvePythonInterpreter(pythonPath, venv)
+		return NewPythonWorkerGroup(iface, module, dir, venv, lifespan, rt, workers, pythonBin, cacheAddr, envFiles, envVars, startTimeout, logger)
+	}
+	f.app, err = NewDynamicApp(modulePattern, f.WorkingDir, f.VenvPath, envFilePatterns, envVarPatterns, factory, f.logger, autoreload, nil)
+	if err != nil {
+		return err
+	}
+	f.logger.Info("serving dynamic "+iface+" app",
+		zap.String("module_"+iface, modulePattern),
+		zap.String("working_dir", f.WorkingDir),
+		zap.String("venv_path", f.VenvPath),
+	)
 	return nil
 }
 
@@ -655,6 +627,47 @@ func writeCaddysnakePyBundle() (scriptPath, bundleDir string, err error) {
 	return scriptPath, bundleDir, nil
 }
 
+// Shared worker script bundle: one temp copy of caddysnake.py is reused across
+// worker groups (important for dynamic multi-tenant apps).
+type pyBundle struct {
+	scriptPath string
+	dir        string
+	refs       int
+}
+
+var (
+	sharedBundleMu sync.Mutex
+	sharedBundle   *pyBundle
+)
+
+func acquireCaddysnakePyBundle() (scriptPath, bundleDir string, err error) {
+	sharedBundleMu.Lock()
+	defer sharedBundleMu.Unlock()
+	if sharedBundle != nil {
+		sharedBundle.refs++
+		return sharedBundle.scriptPath, sharedBundle.dir, nil
+	}
+	scriptPath, bundleDir, err = writeCaddysnakePyBundle()
+	if err != nil {
+		return "", "", err
+	}
+	sharedBundle = &pyBundle{scriptPath: scriptPath, dir: bundleDir, refs: 1}
+	return scriptPath, bundleDir, nil
+}
+
+func releaseCaddysnakePyBundle() {
+	sharedBundleMu.Lock()
+	defer sharedBundleMu.Unlock()
+	if sharedBundle == nil {
+		return
+	}
+	sharedBundle.refs--
+	if sharedBundle.refs <= 0 {
+		_ = os.RemoveAll(sharedBundle.dir)
+		sharedBundle = nil
+	}
+}
+
 // proxyBufferPool implements httputil.BufferPool using sync.Pool to reduce GC pressure.
 type proxyBufferPool struct {
 	pool sync.Pool
@@ -774,11 +787,25 @@ func (w *PythonWorker) Start() error {
 		},
 		Transport:  w.Transport,
 		BufferPool: sharedProxyBufferPool,
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			if w.logger != nil {
+				w.logger.Error("python worker proxy error",
+					zap.String("app", w.App),
+					zap.String("interface", w.Interface),
+					zap.Error(err),
+				)
+			}
+			rw.WriteHeader(http.StatusBadGateway)
+		},
 	}
 
 	workingDir := w.WorkingDir
 	if workingDir == "" {
-		workingDir, _ = os.Getwd()
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return fmt.Errorf("working directory: %w", cwdErr)
+		}
+		workingDir = cwd
 	}
 
 	args := []string{
@@ -1035,7 +1062,7 @@ type PythonWorkerGroup struct {
 }
 
 func NewPythonWorkerGroup(iface, app, workingDir, venv, lifespan, runtime string, count int, pythonBin, cacheAddr string, envFiles []string, envVars map[string]string, startTimeout time.Duration, logger *zap.Logger) (*PythonWorkerGroup, error) {
-	scriptPath, bundleDir, err := writeCaddysnakePyBundle()
+	scriptPath, bundleDir, err := acquireCaddysnakePyBundle()
 	if err != nil {
 		return nil, fmt.Errorf("failed to write worker bundle: %w", err)
 	}
@@ -1069,7 +1096,8 @@ func (wg *PythonWorkerGroup) Cleanup() error {
 		}
 	}
 	if wg.BundleDir != "" {
-		_ = os.RemoveAll(wg.BundleDir)
+		releaseCaddysnakePyBundle()
+		wg.BundleDir = ""
 	}
 	return errors.Join(errs...)
 }
@@ -1338,63 +1366,4 @@ func pythonServer(fs caddycmd.Flags) (int, error) {
 	log.Printf("Serving Python app on %s", listen)
 
 	select {}
-}
-
-// findSitePackagesInVenv searches for the site-packages directory in a given venv.
-func findSitePackagesInVenv(venvPath string) (string, error) {
-	var sitePackagesPath string
-	if runtime.GOOS == "windows" {
-		sitePackagesPath = filepath.Join(venvPath, "Lib\\site-packages")
-	} else {
-		libPath := filepath.Join(venvPath, "lib")
-		pythonDir, err := findPythonDirectory(libPath)
-		if err != nil {
-			return "", err
-		}
-		sitePackagesPath = filepath.Join(libPath, pythonDir, "site-packages")
-	}
-	fileInfo, err := os.Stat(sitePackagesPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("site-packages directory does not exist in: %s", sitePackagesPath)
-		}
-		return "", err
-	}
-	if !fileInfo.IsDir() {
-		return "", fmt.Errorf("found site-packages is not a directory: %s", sitePackagesPath)
-	}
-	return sitePackagesPath, nil
-}
-
-// findWorkingDirectory checks if the directory exists and returns the absolute path
-func findWorkingDirectory(workingDir string) (string, error) {
-	workingDirAbs, err := filepath.Abs(workingDir)
-	if err != nil {
-		return "", err
-	}
-	fileInfo, err := os.Stat(workingDirAbs)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("working_dir directory does not exist in: %s", workingDirAbs)
-		}
-		return "", err
-	}
-	if !fileInfo.IsDir() {
-		return "", fmt.Errorf("working_dir is not a directory: %s", workingDirAbs)
-	}
-	return workingDirAbs, nil
-}
-
-// findPythonDirectory searches for a directory that matches "python3.*" inside the given libPath.
-func findPythonDirectory(libPath string) (string, error) {
-	entries, err := os.ReadDir(libPath)
-	if err != nil {
-		return "", fmt.Errorf("unable to read venv lib directory: %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "python3") {
-			return e.Name(), nil
-		}
-	}
-	return "", errors.New("unable to find a python3.* directory in the venv")
 }

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -30,60 +30,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func TestFindSitePackagesInVenv(t *testing.T) {
-	tempDir := t.TempDir()
-	venvLibPath := filepath.Join(tempDir, "lib", "python3.12", "site-packages")
-
-	err := os.MkdirAll(venvLibPath, 0755)
-	if err != nil {
-		t.Fatalf("failed to create test directory structure: %v", err)
-	}
-
-	result, err := findSitePackagesInVenv(tempDir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	expectedPath := venvLibPath
-	if result != expectedPath {
-		t.Errorf("expected %s, got %s", expectedPath, result)
-	}
-}
-
-func TestFindSitePackagesInVenv_NoPythonDirectory(t *testing.T) {
-	tempDir := t.TempDir()
-
-	_, err := findSitePackagesInVenv(tempDir)
-	if err == nil {
-		t.Fatalf("expected an error, but got none")
-	}
-
-	errStr := err.Error()
-	if !strings.Contains(errStr, "unable to find a python3") && !strings.Contains(errStr, "unable to read venv lib directory") {
-		t.Errorf("expected python directory error, got %q", errStr)
-	}
-}
-
-func TestFindSitePackagesInVenv_NoSitePackages(t *testing.T) {
-	tempDir := t.TempDir()
-	libPath := filepath.Join(tempDir, "lib", "python3.12")
-
-	err := os.MkdirAll(libPath, 0755)
-	if err != nil {
-		t.Fatalf("failed to create test directory structure: %v", err)
-	}
-
-	_, err = findSitePackagesInVenv(tempDir)
-	if err == nil {
-		t.Fatalf("expected an error, but got none")
-	}
-
-	expectedError := "site-packages directory does not exist"
-	if !strings.HasPrefix(err.Error(), expectedError) {
-		t.Errorf("expected error %q, got %q", expectedError, err.Error())
-	}
-}
-
 func TestContainsPlaceholder(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -264,31 +210,6 @@ func (m *mockAppServer) Cleanup() error {
 		m.onCleanup()
 	}
 	return m.cleanupErr
-}
-
-func TestFindWorkingDirectory(t *testing.T) {
-	tempDir := t.TempDir()
-
-	abs, err := findWorkingDirectory(tempDir)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if abs != tempDir {
-		t.Errorf("expected %q, got %q", tempDir, abs)
-	}
-
-	nonExistent := tempDir + "-doesnotexist"
-	_, err = findWorkingDirectory(nonExistent)
-	if err == nil || !strings.Contains(err.Error(), "working_dir directory does not exist") {
-		t.Errorf("expected error for non-existent directory, got: %v", err)
-	}
-
-	filePath := filepath.Join(tempDir, "afile.txt")
-	os.WriteFile(filePath, []byte("test"), 0644)
-	_, err = findWorkingDirectory(filePath)
-	if err == nil || !strings.Contains(err.Error(), "working_dir is not a directory") {
-		t.Errorf("expected error for file, got: %v", err)
-	}
 }
 
 // ====================== UnmarshalCaddyfile Tests ======================
@@ -1257,70 +1178,112 @@ func TestDynamicAppConcurrentDifferentKeys(t *testing.T) {
 	d.mu.RUnlock()
 }
 
-// ====================== findPythonDirectory Tests ======================
+func TestDynamicAppEvictsLRUWhenAtCapacity(t *testing.T) {
+	var cleaned atomic.Int32
+	d, _ := NewDynamicApp("main:app", "", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
+			return &mockAppServer{
+				onCleanup: func() { cleaned.Add(1) },
+			}, nil
+		},
+		zap.NewNop(),
+		false,
+		nil,
+	)
+	d.maxApps = 2
+	d.idleTTL = time.Hour
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	d.now = func() time.Time { return base }
 
-func TestFindPythonDirectory_Found(t *testing.T) {
-	tempDir := t.TempDir()
-	os.MkdirAll(filepath.Join(tempDir, "python3.13"), 0755)
+	if _, err := d.getOrCreateApp("a", "main:app", "/home/a", "", nil, nil); err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	d.now = func() time.Time { return base.Add(time.Minute) }
+	if _, err := d.getOrCreateApp("b", "main:app", "/home/b", "", nil, nil); err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+	d.now = func() time.Time { return base.Add(2 * time.Minute) }
+	if _, err := d.getOrCreateApp("c", "main:app", "/home/c", "", nil, nil); err != nil {
+		t.Fatalf("create c: %v", err)
+	}
 
-	dir, err := findPythonDirectory(tempDir)
+	d.mu.RLock()
+	_, hasA := d.apps["a"]
+	_, hasB := d.apps["b"]
+	_, hasC := d.apps["c"]
+	n := len(d.apps)
+	d.mu.RUnlock()
+	if n != 2 {
+		t.Fatalf("expected 2 apps cached, got %d", n)
+	}
+	if hasA {
+		t.Fatal("expected LRU key a to be evicted")
+	}
+	if !hasB || !hasC {
+		t.Fatalf("expected b and c to remain (hasB=%v hasC=%v)", hasB, hasC)
+	}
+}
+
+func TestDynamicAppExpiresIdleApps(t *testing.T) {
+	d, _ := NewDynamicApp("main:app", "", "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
+			return &mockAppServer{}, nil
+		},
+		zap.NewNop(),
+		false,
+		nil,
+	)
+	d.maxApps = 10
+	d.idleTTL = 5 * time.Minute
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	d.now = func() time.Time { return base }
+
+	if _, err := d.getOrCreateApp("old", "main:app", "/home/old", "", nil, nil); err != nil {
+		t.Fatalf("create old: %v", err)
+	}
+	d.now = func() time.Time { return base.Add(10 * time.Minute) }
+	if _, err := d.getOrCreateApp("new", "main:app", "/home/new", "", nil, nil); err != nil {
+		t.Fatalf("create new: %v", err)
+	}
+
+	d.mu.RLock()
+	_, hasOld := d.apps["old"]
+	_, hasNew := d.apps["new"]
+	d.mu.RUnlock()
+	if hasOld {
+		t.Fatal("expected idle app to be expired")
+	}
+	if !hasNew {
+		t.Fatal("expected new app to be present")
+	}
+}
+
+func TestAcquireCaddysnakePyBundleShared(t *testing.T) {
+	sharedBundleMu.Lock()
+	if sharedBundle != nil {
+		sharedBundleMu.Unlock()
+		t.Fatal("shared bundle already held; test isolation broken")
+	}
+	sharedBundleMu.Unlock()
+
+	p1, d1, err := acquireCaddysnakePyBundle()
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("acquire 1: %v", err)
 	}
-	if dir != "python3.13" {
-		t.Errorf("expected 'python3.13', got %q", dir)
-	}
-}
-
-func TestFindPythonDirectory_MultipleVersions(t *testing.T) {
-	tempDir := t.TempDir()
-	os.MkdirAll(filepath.Join(tempDir, "python3.12"), 0755)
-	os.MkdirAll(filepath.Join(tempDir, "python3.14"), 0755)
-
-	dir, err := findPythonDirectory(tempDir)
+	p2, d2, err := acquireCaddysnakePyBundle()
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("acquire 2: %v", err)
 	}
-	if dir != "python3.12" && dir != "python3.14" {
-		t.Errorf("expected 'python3.12' or 'python3.14', got %q", dir)
+	if p1 != p2 || d1 != d2 {
+		t.Fatalf("expected shared bundle paths, got %q/%q vs %q/%q", p1, d1, p2, d2)
 	}
-}
-
-func TestFindPythonDirectory_NotFound(t *testing.T) {
-	tempDir := t.TempDir()
-	os.MkdirAll(filepath.Join(tempDir, "not-python"), 0755)
-
-	_, err := findPythonDirectory(tempDir)
-	if err == nil {
-		t.Fatal("expected error for missing python directory")
+	releaseCaddysnakePyBundle()
+	if _, err := os.Stat(p1); err != nil {
+		t.Fatalf("bundle should remain after first release: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unable to find") {
-		t.Errorf("expected 'unable to find' in error, got: %v", err)
-	}
-}
-
-func TestFindPythonDirectory_EmptyDir(t *testing.T) {
-	tempDir := t.TempDir()
-	_, err := findPythonDirectory(tempDir)
-	if err == nil {
-		t.Fatal("expected error for empty directory")
-	}
-}
-
-func TestFindPythonDirectory_NonExistentPath(t *testing.T) {
-	_, err := findPythonDirectory("/nonexistent/path/to/lib")
-	if err == nil {
-		t.Fatal("expected error for non-existent path")
-	}
-}
-
-func TestFindPythonDirectory_FileNotDir(t *testing.T) {
-	tempDir := t.TempDir()
-	os.WriteFile(filepath.Join(tempDir, "python3.13"), []byte("not a dir"), 0644)
-
-	_, err := findPythonDirectory(tempDir)
-	if err == nil {
-		t.Fatal("expected error when python3.x is a file, not directory")
+	releaseCaddysnakePyBundle()
+	if _, err := os.Stat(p1); !os.IsNotExist(err) {
+		t.Fatalf("expected bundle removed after final release, err=%v", err)
 	}
 }
 
@@ -1399,25 +1362,6 @@ func TestUnmarshalCaddyfile_LifespanMissingArg(t *testing.T) {
 	err := cs.UnmarshalCaddyfile(d)
 	if err == nil {
 		t.Fatal("expected error for missing lifespan argument")
-	}
-}
-
-func TestFindSitePackagesInVenv_SitePackagesIsFile(t *testing.T) {
-	tempDir := t.TempDir()
-	pythonDir := filepath.Join(tempDir, "lib", "python3.12")
-	err := os.MkdirAll(pythonDir, 0755)
-	if err != nil {
-		t.Fatalf("failed to create test directory: %v", err)
-	}
-	sitePackagesPath := filepath.Join(pythonDir, "site-packages")
-	os.WriteFile(sitePackagesPath, []byte("not a dir"), 0644)
-
-	_, err = findSitePackagesInVenv(tempDir)
-	if err == nil {
-		t.Fatal("expected error when site-packages is a file")
-	}
-	if !strings.Contains(err.Error(), "not a directory") {
-		t.Errorf("expected 'not a directory' in error, got: %v", err)
 	}
 }
 

--- a/caddysnake_test.go
+++ b/caddysnake_test.go
@@ -1260,9 +1260,9 @@ func TestDynamicAppExpiresIdleApps(t *testing.T) {
 
 func TestAcquireCaddysnakePyBundleShared(t *testing.T) {
 	sharedBundleMu.Lock()
+	beforeRefs := 0
 	if sharedBundle != nil {
-		sharedBundleMu.Unlock()
-		t.Fatal("shared bundle already held; test isolation broken")
+		beforeRefs = sharedBundle.refs
 	}
 	sharedBundleMu.Unlock()
 
@@ -1277,13 +1277,37 @@ func TestAcquireCaddysnakePyBundleShared(t *testing.T) {
 	if p1 != p2 || d1 != d2 {
 		t.Fatalf("expected shared bundle paths, got %q/%q vs %q/%q", p1, d1, p2, d2)
 	}
+
+	sharedBundleMu.Lock()
+	midRefs := 0
+	if sharedBundle != nil {
+		midRefs = sharedBundle.refs
+	}
+	sharedBundleMu.Unlock()
+	if midRefs != beforeRefs+2 {
+		t.Fatalf("expected refs %d after two acquires, got %d", beforeRefs+2, midRefs)
+	}
+
 	releaseCaddysnakePyBundle()
 	if _, err := os.Stat(p1); err != nil {
 		t.Fatalf("bundle should remain after first release: %v", err)
 	}
 	releaseCaddysnakePyBundle()
-	if _, err := os.Stat(p1); !os.IsNotExist(err) {
-		t.Fatalf("expected bundle removed after final release, err=%v", err)
+
+	sharedBundleMu.Lock()
+	afterRefs := 0
+	alive := sharedBundle != nil
+	if alive {
+		afterRefs = sharedBundle.refs
+	}
+	sharedBundleMu.Unlock()
+	if afterRefs != beforeRefs {
+		t.Fatalf("expected refs restored to %d, got %d (alive=%v)", beforeRefs, afterRefs, alive)
+	}
+	if beforeRefs == 0 {
+		if _, err := os.Stat(p1); !os.IsNotExist(err) {
+			t.Fatalf("expected bundle removed after final release, err=%v", err)
+		}
 	}
 }
 

--- a/docs/blog/2026-02-09-dynamic-modules-autoreload.md
+++ b/docs/blog/2026-02-09-dynamic-modules-autoreload.md
@@ -54,7 +54,7 @@ When you save a Python file, the app is automatically reloaded without restartin
 4. The old app is cleaned up and a new one is imported
 5. A read/write lock ensures in-flight requests complete before the swap
 
-If the reload fails (e.g. syntax error), requests return HTTP 500 until the code is fixed.
+If the reload fails (e.g. syntax error), requests return HTTP 503 until the code is fixed.
 
 ## Dynamic Modules + Autoreload
 

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -62,7 +62,7 @@ The autoreload feature provides hot-reloading during development without restart
    - The new worker group replaces the old one atomically
    - Old worker processes are terminated after the swap
 5. A read/write lock ensures in-flight requests complete before the swap
-6. If the reload fails (e.g. syntax error in Python code), all subsequent requests return HTTP 500 until the next successful reload
+6. If the reload fails (e.g. syntax error in Python code), all subsequent requests return HTTP 503 until the next successful reload
 7. If the app cannot be recreated at all (e.g. the working directory was deleted), the process terminates with exit code 1 to avoid silently serving errors indefinitely
 
 ### Thread safety
@@ -139,9 +139,13 @@ The ASGI implementation in [`caddysnake.py`](https://github.com/mliezun/caddy-sn
 
 ## Current Limitations
 
-### Virtual Environment Sharing
+### Shared cache has no tenant isolation
 
-When a `venv` is specified, the packages are added to the global `sys.path`. This means all Python apps served by the same Caddy instance have access to those packages, regardless of which app the venv was configured for.
+The in-process shared cache is visible to every worker attached to the same `python` handler. Use key prefixes per app/tenant, or an external store, when isolation is required.
+
+### Dynamic app cache is bounded, not infinite
+
+Multi-tenant `DynamicApp` caches are capped (default 128 apps, 30m idle TTL). Very large tenant counts need higher limits via env vars or an external routing design.
 
 ---
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -21,19 +21,23 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class Item(BaseModel):
     name: str
     description: str | None = None
     price: float
     tax: float | None = None
 
+
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
 
+
 @app.get("/items/{item_id}")
 def read_item(item_id: int):
     return {"item_id": item_id}
+
 
 @app.post("/items/")
 def create_item(item: Item):
@@ -83,13 +87,16 @@ from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
+
 @app.route("/")
 def hello():
     return jsonify({"message": "Hello, World!"})
 
+
 @app.route("/items/<int:item_id>")
 def get_item(item_id):
     return jsonify({"item_id": item_id})
+
 
 @app.route("/items", methods=["POST"])
 def create_item():
@@ -175,26 +182,29 @@ Django is a full-featured web framework with a built-in admin interface and ORM.
 ```python
 # mysite/settings.py
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'items',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "items",
 ]
 
 # items/models.py
 from django.db import models
+
 
 class Item(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+
 # items/views.py
 from django.http import JsonResponse
 from .models import Item
+
 
 def item_list(request):
     items = Item.objects.all()
@@ -241,7 +251,7 @@ Django Channels extends Django with WebSocket support and other async protocols.
 import os
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 application = get_asgi_application()
 ```
 
@@ -278,22 +288,26 @@ from socketio import AsyncServer
 from socketio.asgi import ASGIApp
 
 app = FastAPI()
-sio = AsyncServer(async_mode='asgi')
+sio = AsyncServer(async_mode="asgi")
 socket_app = ASGIApp(sio)
+
 
 @sio.event
 async def connect(sid, environ):
     print(f"Client connected: {sid}")
 
+
 @sio.event
 async def disconnect(sid):
     print(f"Client disconnected: {sid}")
 
+
 @sio.event
 async def message(sid, data):
-    await sio.emit('message', data, skip_sid=sid)
+    await sio.emit("message", data, skip_sid=sid)
 
-app.mount('/', socket_app)
+
+app.mount("/", socket_app)
 ```
 
 ```caddyfile
@@ -341,6 +355,7 @@ Enable hot-reloading during development so your app reloads automatically when y
 from flask import Flask
 
 app = Flask(__name__)
+
 
 @app.route("/")
 def hello():
@@ -401,6 +416,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/")
 def index():
     return {"app": "app1", "message": "Hello from App 1!"}
@@ -411,6 +427,7 @@ def index():
 from fastapi import FastAPI
 
 app = FastAPI()
+
 
 @app.get("/")
 def index():

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -358,7 +358,7 @@ http://localhost:9080 {
 }
 ```
 
-Now when you edit `main.py`, the app reloads automatically — no need to restart Caddy. If you introduce a syntax error, requests will return HTTP 500 until you fix the code.
+Now when you edit `main.py`, the app reloads automatically — no need to restart Caddy. If you introduce a syntax error, requests will return HTTP 503 until you fix the code.
 
 :::note
 Changes are debounced (500ms) to handle rapid edits.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -122,6 +122,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/hello-world")
 def hello():
     return "Hello world!"
@@ -162,6 +163,7 @@ It's possible to enable/disable [lifespan events](https://fastapi.tiangolo.com/a
 from flask import Flask
 
 app = Flask(__name__)
+
 
 @app.route("/hello-world")
 def hello():

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -46,6 +46,7 @@ This starts a server on port `9080` serving your app. See `caddysnake --help` fo
 | `--domain <example.com>` | Enable HTTPS with automatic certificates | — |
 | `--listen <addr>` | Custom listen address | `:9080` |
 | `--workers <count>` | Number of worker processes | CPU count |
+| `--python-path <path>` | Path to the Python interpreter | system/venv python |
 | `--venv <path>` | Path to a Python virtual environment | — |
 | `--working-dir <path>` | Working directory for the Python app | — |
 | `--env-file <path>` | Dotenv file for worker env (repeatable) | — |
@@ -236,10 +237,10 @@ python {
 }
 ```
 
-Behind the scenes, this appends `venv/lib/python3.x/site-packages` to `sys.path` so installed packages are available to your app.
+Each Python worker process adds that venv’s `site-packages` to its own `sys.path` so installed packages are available to your app.
 
 :::note
-The venv packages are added to the global `sys.path`, which means all Python apps served by Caddy share the same packages.
+Workers are separate processes: a venv configured for one `python` handler (or one dynamic tenant) does not leak packages into other workers’ interpreters.
 :::
 
 ---

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -207,7 +207,7 @@ Variable names must match `[A-Za-z_][A-Za-z0-9_]*`. Reserved names (`PYTHONUNBUF
 
 ### `venv`
 
-Path to a Python virtual environment. Behind the scenes, this appends `venv/lib/python3.x/site-packages` to `sys.path` so installed packages are available to your app.
+Path to a Python virtual environment. Each Python **worker process** adds that venv’s `site-packages` to its own `sys.path` (via `setup_paths` in the worker), so installed packages are available to your app.
 
 ```caddyfile
 python {
@@ -217,7 +217,7 @@ python {
 ```
 
 :::note
-The venv packages are added to the global `sys.path`, which means all Python apps served by Caddy share the same packages.
+Workers are separate processes: a venv configured for one `python` handler (or one dynamic tenant) does not leak packages into other workers’ interpreters.
 :::
 
 ### `workers`
@@ -269,7 +269,7 @@ python {
 - The Python module cache (`sys.modules`) is invalidated for all modules in the working directory before reimporting
 - The old app is cleaned up and a new one is created seamlessly
 - In-flight requests complete before the swap happens (thread-safe with read/write locks)
-- If the reload fails (e.g. syntax error in Python code), the app degrades to returning HTTP 500 for all requests until the next file change triggers a successful reload
+- If the reload fails (e.g. syntax error in Python code), the app degrades to returning HTTP 503 for all requests until the next file change triggers a successful reload
 - If the app cannot be loaded at all (e.g. app directory deleted), the Caddy process terminates to avoid silently serving errors
 
 ---
@@ -294,6 +294,15 @@ In this example:
 - A request to `app2.example.com` loads the app from the `app2/` directory
 - Apps are **lazily created** on first request and cached for subsequent requests
 
+Cached dynamic apps are bounded to avoid unbounded process growth under multi-tenant Host headers:
+
+| Limit | Default | Override |
+| --- | --- | --- |
+| Max cached apps | **128** | `CADDYSNAKE_MAX_DYNAMIC_APPS` (positive integer) |
+| Idle eviction TTL | **30m** | `CADDYSNAKE_DYNAMIC_APP_IDLE_TTL` (Go duration, e.g. `15m`) |
+
+When the cache is full, the least-recently-used app is evicted (cleaned up after a short grace period). Idle apps past the TTL are expired when a new tenant is created.
+
 ### How it works
 
 When any of the configuration values (`module_wsgi`/`module_asgi`, `working_dir`, `venv`, `env_file`, or `env_var` values) contain Caddy placeholders (e.g. `{http.request.host.labels.2}`), Caddy Snake creates a **DynamicApp** that:
@@ -301,7 +310,7 @@ When any of the configuration values (`module_wsgi`/`module_asgi`, `working_dir`
 1. Resolves the placeholders at request time using the Caddy replacer
 2. Builds a composite cache key from the resolved module, directory, venv, env files, and inline env vars
 3. Returns an existing app if one is cached for that key
-4. Otherwise, lazily imports the Python module and creates a new app instance
+4. Otherwise, lazily imports the Python module and creates a new app instance (evicting LRU/idle entries if needed)
 5. Uses double-check locking for thread-safe concurrent access
 
 ### Dynamic modules + autoreload
@@ -425,12 +434,12 @@ That test requires **Python 3** on `PATH`.
 
 ## Shared worker cache {#shared-worker-cache}
 
-When Caddy Snake runs **Python in process worker mode** (the default multi-process layout), it may start a small **in-process cache server** inside the **Go plugin**. Worker processes talk to it over a **stream socket** using a **RESP2**-shaped line protocol (Redis-compatible enough for simple clients):
+When Caddy Snake provisions a `python` handler, it starts a small **in-process cache server** inside the **Go plugin**. Worker processes talk to it over a **stream socket** using a **RESP2**-shaped line protocol (Redis-compatible enough for simple clients):
 
 - **Linux and macOS:** the listener is a **Unix domain socket** in a private temporary directory. The **`CADDYSNAKE_CACHE_ADDR`** environment variable is set to **`unix:///absolute/path/to/cache.sock`** (three slashes after the scheme: `unix://` plus an absolute path).
 - **Windows:** the listener is **TCP on loopback**; **`CADDYSNAKE_CACHE_ADDR`** is **`127.0.0.1:<port>`**.
 
-Caddy sets these automatically for eligible workers:
+Caddy sets these automatically for each worker:
 
 | Variable | Purpose |
 | --- | --- |
@@ -439,7 +448,7 @@ Caddy sets these automatically for eligible workers:
 | **`CADDYSNAKE_WORKER_ID`** | Stable worker index **`0`…`N-1`** within the worker group (reused after reload; combine with conn/generation in app keys) |
 | **`CADDYSNAKE_CACHE_TIMEOUT`** | Hint for client read/connect timeouts (seconds) |
 
-If **`CADDYSNAKE_CACHE_ADDR`** is unset, the cache client is not available (for example, thread workers or configurations that omit the shared cache).
+If **`CADDYSNAKE_CACHE_ADDR`** is unset (for example, when running Python code outside Caddy), the cache client is not available.
 
 ### How values are stored
 

--- a/dynamic.go
+++ b/dynamic.go
@@ -352,6 +352,9 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		return nil, err
 	}
 	if err == nil {
+		// Refresh after the out-of-lock factory so idle TTL / LRU and the new
+		// entry's lastUsed reflect eviction-time wall clock, not create-start.
+		now = d.now()
 		evicted := d.makeRoomLocked(key, now)
 		if len(d.apps) >= d.maxApps {
 			d.mu.Unlock()

--- a/dynamic.go
+++ b/dynamic.go
@@ -159,12 +159,15 @@ type appCreate struct {
 // contains {host.labels.2}, each subdomain gets its own Python app instance
 // imported from the corresponding directory.
 //
-// Cached apps are bounded by maxApps (default 128) and idleTTL (default 30m).
-// Override with CADDYSNAKE_MAX_DYNAMIC_APPS and CADDYSNAKE_DYNAMIC_APP_IDLE_TTL.
+// Live apps (cached + in-flight creates) are bounded by maxApps (default 128)
+// and idleTTL (default 30m). Override with CADDYSNAKE_MAX_DYNAMIC_APPS and
+// CADDYSNAKE_DYNAMIC_APP_IDLE_TTL. Apps with active requests are not idle/LRU
+// evicted.
 type DynamicApp struct {
 	mu              sync.RWMutex
 	apps            map[string]AppServer
 	lastUsed        map[string]time.Time
+	inUse           map[string]int    // active HandleRequest refs; blocks idle/LRU eviction
 	appDirs         map[string]string // cache key -> resolved working dir (for eviction/autoreload)
 	inflight        map[string]*appCreate
 	closed          bool
@@ -196,6 +199,7 @@ func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns [
 	d := &DynamicApp{
 		apps:                make(map[string]AppServer),
 		lastUsed:            make(map[string]time.Time),
+		inUse:               make(map[string]int),
 		appDirs:             make(map[string]string),
 		inflight:            make(map[string]*appCreate),
 		modulePattern:       modulePattern,
@@ -308,9 +312,19 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		<-c.done
 		return c.app, c.err
 	}
+	// Reserve capacity before running the factory so concurrent first-time
+	// tenants cannot spawn more live worker groups than maxApps.
+	now = d.now()
+	evicted := d.makeRoomLocked(key, now)
+	if len(d.apps)+len(d.inflight) >= d.maxApps {
+		d.mu.Unlock()
+		d.cleanupAppsAsync(evicted)
+		return nil, fmt.Errorf("%w: max %d cached apps (set %s)", errDynamicAppLimit, d.maxApps, envMaxDynamicApps)
+	}
 	c := &appCreate{done: make(chan struct{})}
 	d.inflight[key] = c
 	d.mu.Unlock()
+	d.cleanupAppsAsync(evicted)
 
 	d.logger.Info("dynamically importing python app",
 		zap.String("module", module),
@@ -388,11 +402,12 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 }
 
 // makeRoomLocked expires idle apps and, if still at capacity, evicts the
-// least-recently-used entry (other than excludeKey). Caller holds d.mu.
+// least-recently-used entry (other than excludeKey). Apps with active
+// requests are never evicted here. Caller holds d.mu.
 func (d *DynamicApp) makeRoomLocked(excludeKey string, now time.Time) []AppServer {
 	var evicted []AppServer
 	for key, used := range d.lastUsed {
-		if key == excludeKey {
+		if key == excludeKey || d.inUse[key] > 0 {
 			continue
 		}
 		if now.Sub(used) >= d.idleTTL {
@@ -405,7 +420,7 @@ func (d *DynamicApp) makeRoomLocked(excludeKey string, now time.Time) []AppServe
 		lruKey := ""
 		var lruTime time.Time
 		for key, used := range d.lastUsed {
-			if key == excludeKey {
+			if key == excludeKey || d.inUse[key] > 0 {
 				continue
 			}
 			if lruKey == "" || used.Before(lruTime) {
@@ -438,6 +453,8 @@ func (d *DynamicApp) removeAppLocked(key string) AppServer {
 	}
 	delete(d.apps, key)
 	delete(d.lastUsed, key)
+	// Leave inUse intact so a still-running handler's releaseApp cannot
+	// accidentally unpin a replacement app created for the same key.
 	dir := d.appDirs[key]
 	delete(d.appDirs, key)
 	if d.autoreload && dir != "" {
@@ -446,6 +463,22 @@ func (d *DynamicApp) removeAppLocked(key string) AppServer {
 		}
 	}
 	return app
+}
+
+// releaseApp decrements the active-request refcount for key and refreshes
+// lastUsed when the last request finishes so idle TTL starts after real use.
+func (d *DynamicApp) releaseApp(key string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	n := d.inUse[key]
+	if n <= 1 {
+		delete(d.inUse, key)
+		if _, ok := d.apps[key]; ok {
+			d.lastUsed[key] = d.now()
+		}
+		return
+	}
+	d.inUse[key] = n - 1
 }
 
 func (d *DynamicApp) untrackKeyLocked(absDir, key string) {
@@ -602,22 +635,39 @@ func (d *DynamicApp) reloadDir(absDir string) {
 }
 
 // HandleRequest resolves placeholders from the request, gets or creates the
-// appropriate app, and forwards the request.
+// appropriate app, and forwards the request. The app is pinned for the
+// duration of the handler so idle/LRU eviction cannot tear down workers
+// serving long-lived connections (e.g. WebSockets).
 func (d *DynamicApp) HandleRequest(w http.ResponseWriter, r *http.Request) error {
 	key, module, dir, venv, envFiles, envVars := d.resolve(r)
-	app, err := d.getOrCreateApp(key, module, dir, venv, envFiles, envVars)
-	if err != nil {
-		if d.autoreload && d.exitOnReloadFailure != nil {
-			d.logger.Error("failed to load python app (autoreload); terminating",
-				zap.String("module", module),
-				zap.String("working_dir", dir),
-				zap.Error(err),
-			)
-			d.exitOnReloadFailure(1)
+	for {
+		app, err := d.getOrCreateApp(key, module, dir, venv, envFiles, envVars)
+		if err != nil {
+			if d.autoreload && d.exitOnReloadFailure != nil {
+				d.logger.Error("failed to load python app (autoreload); terminating",
+					zap.String("module", module),
+					zap.String("working_dir", dir),
+					zap.Error(err),
+				)
+				d.exitOnReloadFailure(1)
+			}
+			return err
 		}
-		return err
+		d.mu.Lock()
+		if d.closed {
+			d.mu.Unlock()
+			return errors.New("dynamic app shutting down")
+		}
+		if cur, ok := d.apps[key]; ok && cur == app {
+			d.inUse[key]++
+			d.mu.Unlock()
+			err := app.HandleRequest(w, r)
+			d.releaseApp(key)
+			return err
+		}
+		d.mu.Unlock()
+		// Evicted between lookup and pin; retry get-or-create.
 	}
-	return app.HandleRequest(w, r)
 }
 
 // Cleanup frees all dynamically created apps and stops the autoreload watcher.
@@ -648,6 +698,7 @@ func (d *DynamicApp) Cleanup() error {
 		}
 		delete(d.apps, key)
 		delete(d.lastUsed, key)
+		delete(d.inUse, key)
 		delete(d.appDirs, key)
 	}
 	d.mu.Unlock()

--- a/dynamic.go
+++ b/dynamic.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +19,39 @@ import (
 )
 
 var validModulePattern = regexp.MustCompile(`^[a-zA-Z_][\w.]*:[a-zA-Z_]\w*$`)
+
+const (
+	// defaultMaxDynamicApps caps cached DynamicApp tenants to bound memory/process use.
+	defaultMaxDynamicApps = 128
+	// defaultDynamicAppIdleTTL is how long an unused dynamic app may stay cached.
+	defaultDynamicAppIdleTTL = 30 * time.Minute
+
+	envMaxDynamicApps      = "CADDYSNAKE_MAX_DYNAMIC_APPS"
+	envDynamicAppIdleTTL   = "CADDYSNAKE_DYNAMIC_APP_IDLE_TTL"
+	dynamicAppCleanupGrace = 10 * time.Second
+)
+
+var errDynamicAppLimit = errors.New("dynamic app limit reached")
+
+func parseMaxDynamicApps() int {
+	if v := os.Getenv(envMaxDynamicApps); v != "" {
+		n, err := strconv.Atoi(v)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxDynamicApps
+}
+
+func parseDynamicAppIdleTTL() time.Duration {
+	if v := os.Getenv(envDynamicAppIdleTTL); v != "" {
+		d, err := time.ParseDuration(v)
+		if err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultDynamicAppIdleTTL
+}
 
 // hasDotDotSegment reports whether the raw (pre-normalization) path contains
 // a ".." segment. Checking before filepath.Abs/Clean is important: those
@@ -124,9 +158,14 @@ type appCreate struct {
 // Caddy placeholders resolved at request time. For example, when working_dir
 // contains {host.labels.2}, each subdomain gets its own Python app instance
 // imported from the corresponding directory.
+//
+// Cached apps are bounded by maxApps (default 128) and idleTTL (default 30m).
+// Override with CADDYSNAKE_MAX_DYNAMIC_APPS and CADDYSNAKE_DYNAMIC_APP_IDLE_TTL.
 type DynamicApp struct {
 	mu              sync.RWMutex
 	apps            map[string]AppServer
+	lastUsed        map[string]time.Time
+	appDirs         map[string]string // cache key -> resolved working dir (for eviction/autoreload)
 	inflight        map[string]*appCreate
 	closed          bool
 	modulePattern   string
@@ -136,6 +175,9 @@ type DynamicApp struct {
 	envVarPatterns  map[string]string
 	factory         appFactory
 	logger          *zap.Logger
+	maxApps         int
+	idleTTL         time.Duration
+	now             func() time.Time // overridable in tests
 
 	// Autoreload fields
 	autoreload          bool
@@ -153,6 +195,8 @@ type DynamicApp struct {
 func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns []string, envVarPatterns map[string]string, factory appFactory, logger *zap.Logger, autoreload bool, exitOnReloadFailure func(code int)) (*DynamicApp, error) {
 	d := &DynamicApp{
 		apps:                make(map[string]AppServer),
+		lastUsed:            make(map[string]time.Time),
+		appDirs:             make(map[string]string),
 		inflight:            make(map[string]*appCreate),
 		modulePattern:       modulePattern,
 		workingDir:          workingDir,
@@ -161,10 +205,12 @@ func NewDynamicApp(modulePattern, workingDir, venvPath string, envFilePatterns [
 		envVarPatterns:      cloneEnvVars(envVarPatterns),
 		factory:             factory,
 		logger:              logger,
+		maxApps:             parseMaxDynamicApps(),
+		idleTTL:             parseDynamicAppIdleTTL(),
+		now:                 time.Now,
 		autoreload:          autoreload,
 		exitOnReloadFailure: exitOnReloadFailure,
 	}
-
 	if autoreload {
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
@@ -223,6 +269,8 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		}
 	}
 
+	now := d.now()
+
 	d.mu.RLock()
 	if d.closed {
 		d.mu.RUnlock()
@@ -231,7 +279,17 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 	app, ok := d.apps[key]
 	d.mu.RUnlock()
 	if ok {
-		return app, nil
+		d.mu.Lock()
+		if d.closed {
+			d.mu.Unlock()
+			return nil, errors.New("dynamic app shutting down")
+		}
+		if _, still := d.apps[key]; still {
+			d.lastUsed[key] = now
+			d.mu.Unlock()
+			return app, nil
+		}
+		d.mu.Unlock()
 	}
 
 	d.mu.Lock()
@@ -241,6 +299,7 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 	}
 	app, ok = d.apps[key]
 	if ok {
+		d.lastUsed[key] = now
 		d.mu.Unlock()
 		return app, nil
 	}
@@ -293,10 +352,29 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		return nil, err
 	}
 	if err == nil {
+		evicted := d.makeRoomLocked(key, now)
+		if len(d.apps) >= d.maxApps {
+			d.mu.Unlock()
+			_ = app.Cleanup()
+			err = fmt.Errorf("%w: max %d cached apps (set %s)", errDynamicAppLimit, d.maxApps, envMaxDynamicApps)
+			c.app = nil
+			c.err = err
+			close(c.done)
+			d.cleanupAppsAsync(evicted)
+			return nil, err
+		}
 		d.apps[key] = app
+		d.lastUsed[key] = now
+		d.appDirs[key] = dir
 		if d.autoreload && dir != "" {
 			d.startWatchingDir(dir, key)
 		}
+		d.mu.Unlock()
+		d.cleanupAppsAsync(evicted)
+		c.app = app
+		c.err = nil
+		close(c.done)
+		return app, nil
 	}
 	c.app = app
 	c.err = err
@@ -306,6 +384,98 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 	return app, err
 }
 
+// makeRoomLocked expires idle apps and, if still at capacity, evicts the
+// least-recently-used entry (other than excludeKey). Caller holds d.mu.
+func (d *DynamicApp) makeRoomLocked(excludeKey string, now time.Time) []AppServer {
+	var evicted []AppServer
+	for key, used := range d.lastUsed {
+		if key == excludeKey {
+			continue
+		}
+		if now.Sub(used) >= d.idleTTL {
+			if app := d.removeAppLocked(key); app != nil {
+				evicted = append(evicted, app)
+			}
+		}
+	}
+	for len(d.apps) >= d.maxApps {
+		lruKey := ""
+		var lruTime time.Time
+		for key, used := range d.lastUsed {
+			if key == excludeKey {
+				continue
+			}
+			if lruKey == "" || used.Before(lruTime) {
+				lruKey = key
+				lruTime = used
+			}
+		}
+		if lruKey == "" {
+			break
+		}
+		if app := d.removeAppLocked(lruKey); app != nil {
+			evicted = append(evicted, app)
+			d.logger.Info("evicted dynamic python app (cache full)",
+				zap.String("key", lruKey),
+				zap.Int("max_apps", d.maxApps),
+			)
+		} else {
+			break
+		}
+	}
+	return evicted
+}
+
+// removeAppLocked deletes a cached app and its autoreload bookkeeping.
+// Caller holds d.mu. Returns the app for async Cleanup.
+func (d *DynamicApp) removeAppLocked(key string) AppServer {
+	app, ok := d.apps[key]
+	if !ok {
+		return nil
+	}
+	delete(d.apps, key)
+	delete(d.lastUsed, key)
+	dir := d.appDirs[key]
+	delete(d.appDirs, key)
+	if d.autoreload && dir != "" {
+		if absDir, err := filepath.Abs(dir); err == nil {
+			d.untrackKeyLocked(absDir, key)
+		}
+	}
+	return app
+}
+
+func (d *DynamicApp) untrackKeyLocked(absDir, key string) {
+	keys := d.dirToKeys[absDir]
+	if len(keys) == 0 {
+		return
+	}
+	out := keys[:0]
+	for _, k := range keys {
+		if k != key {
+			out = append(out, k)
+		}
+	}
+	if len(out) == 0 {
+		delete(d.dirToKeys, absDir)
+		return
+	}
+	d.dirToKeys[absDir] = out
+}
+
+func (d *DynamicApp) cleanupAppsAsync(apps []AppServer) {
+	if len(apps) == 0 {
+		return
+	}
+	go func() {
+		time.Sleep(dynamicAppCleanupGrace)
+		for _, app := range apps {
+			if err := app.Cleanup(); err != nil {
+				d.logger.Error("failed to cleanup old dynamic app", zap.Error(err))
+			}
+		}
+	}()
+}
 func (d *DynamicApp) startWatchingDir(dir, key string) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -411,9 +581,8 @@ func (d *DynamicApp) reloadDir(absDir string) {
 
 	var oldApps []AppServer
 	for _, key := range keys {
-		if app, exists := d.apps[key]; exists {
+		if app := d.removeAppLocked(key); app != nil {
 			oldApps = append(oldApps, app)
-			delete(d.apps, key)
 		}
 	}
 
@@ -426,18 +595,7 @@ func (d *DynamicApp) reloadDir(absDir string) {
 		zap.Int("apps_evicted", len(oldApps)),
 	)
 
-	if len(oldApps) > 0 {
-		go func() {
-			time.Sleep(10 * time.Second)
-			for _, app := range oldApps {
-				if err := app.Cleanup(); err != nil {
-					d.logger.Error("failed to cleanup old dynamic app",
-						zap.Error(err),
-					)
-				}
-			}
-		}()
-	}
+	d.cleanupAppsAsync(oldApps)
 }
 
 // HandleRequest resolves placeholders from the request, gets or creates the
@@ -486,6 +644,8 @@ func (d *DynamicApp) Cleanup() error {
 			errs = append(errs, err)
 		}
 		delete(d.apps, key)
+		delete(d.lastUsed, key)
+		delete(d.appDirs, key)
 	}
 	d.mu.Unlock()
 	return errors.Join(errs...)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the highest-value code quality improvements identified in a codebase review: resource bounds for multi-tenant dynamic apps, worker/proxy hardening, dead-code removal, and documentation corrections.

## Changes

### DynamicApp resource bounds
- Cap cached dynamic apps at **128** (override with `CADDYSNAKE_MAX_DYNAMIC_APPS`)
- Expire idle apps after **30m** (override with `CADDYSNAKE_DYNAMIC_APP_IDLE_TTL`)
- Evict least-recently-used tenants when the cache is full
- Document limits in `docs/docs/reference.md` and README

### Worker / provisioning hardening
- Share one embedded `caddysnake.py` temp bundle across worker groups (refcount), reducing I/O for dynamic multi-tenant setups
- Unify WSGI/ASGI/ESGI provisioning via `pythonInterfaceAndModule()`
- Log reverse-proxy failures with a custom `ErrorHandler` (502)
- Fail clearly on invalid `workers` / missing cwd instead of swallowing errors
- Remove unused `findSitePackagesInVenv` / `findWorkingDirectory` / `findPythonDirectory` helpers and their tests
- Drop file-wide `unused` lint exclusion on `cache_server.go` and remove dead `respWriteBulkString`

### Docs drift fixes
- Autoreload failure status is **503** (was incorrectly documented as 500)
- Venv packages are per-worker-process (not a shared global `sys.path`)
- Shared cache always starts with the `python` handler (not optional / “thread workers”)
- Platform table: process workers on all platforms (including Windows via loopback TCP)
- Add missing `--python-path` to intro CLI table; clarify defaults

### Tests
- LRU eviction + idle expiry for `DynamicApp`
- Shared bundle acquire/release (tolerant of in-use bundle from other tests)
- Concurrent `Get` while `Pop` is blocked (documents that `sync.Cond.Wait` unlocks the store mutex)

## Verification
- `go test -race -count=1 -tags=caddytest -timeout 180s .` (pass)
- `golangci-lint run --tests=true .` (pass)
- `ruff format --check` on touched docs (pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1633c65-3b78-4c22-9718-695f97146208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1633c65-3b78-4c22-9718-695f97146208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

