### PR TITLE
fix(autoreload): follow a symlinked working_dir when registering watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,14 @@ Enables ASGI [lifespan events](https://asgi.readthedocs.io/en/latest/specs/lifes
 
 Watches the working directory for `.py` file changes and automatically reloads the Python app. Useful during development.
 
-Changes are debounced (500ms) to handle rapid edits.
+Changes are debounced (500ms) to handle rapid edits. The working directory is resolved through symlinks before
+watching, so a `releases/active -> releases/main` style root is watched correctly; the tree is resolved once, at
+start, so re-pointing the symlink at a new directory still needs a Caddy reload.
+
+> **This is a development feature.** The reload swaps the app under a write lock while requests hold a read lock
+> for their whole lifetime, so an open WebSocket or streaming response blocks the swap — and Go's `RWMutex` then
+> queues new requests behind it. In production, reload Caddy instead (`caddy reload --force`), which keeps the
+> listeners up and does not block.
 
 ```Caddyfile
 python {
@@ -463,9 +470,10 @@ For **[nip.io](https://nip.io/)** names like **`app7.203.0.113.43.nip.io`**, the
 
 There are two approaches for hot reloading during development:
 
-### Built-in autoreload (recommended)
+### Built-in autoreload (recommended for development)
 
-Add the `autoreload` directive to your Caddyfile. This watches for `.py` file changes and reloads the app in-place without restarting Caddy:
+Add the `autoreload` directive to your Caddyfile. This watches for `.py` file changes and starts fresh Python
+workers without restarting Caddy (it is not an in-process reimport):
 
 ```Caddyfile
 python {

--- a/autoreload.go
+++ b/autoreload.go
@@ -13,7 +13,28 @@ import (
 
 // watchDirRecursive adds all directories under root to the fsnotify watcher.
 // It is used by both AutoreloadableApp and DynamicApp.
+//
+// The root is resolved through symlinks first. filepath.Walk lstat()s its root
+// and refuses to descend into a symlink, so a working_dir like the
+// `releases/active -> releases/main` indirection common to release-directory
+// deploys would otherwise add zero watches and silently never reload.
+// Only the root is resolved: symlinks *inside* the tree are still not followed,
+// so the walk stays free of cycles and of excursions outside the app.
 func watchDirRecursive(watcher *fsnotify.Watcher, root string, logger *zap.Logger) {
+	if resolved, err := filepath.EvalSymlinks(root); err != nil {
+		// Broken or unreadable link: fall back to the literal path, which
+		// leaves a non-symlinked root behaving exactly as before.
+		logger.Warn("autoreload: failed to resolve working directory symlinks",
+			zap.String("path", root),
+			zap.Error(err),
+		)
+	} else if resolved != root {
+		logger.Info("autoreload: resolved working directory symlink",
+			zap.String("path", root),
+			zap.String("resolved", resolved),
+		)
+		root = resolved
+	}
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/autoreload.go
+++ b/autoreload.go
@@ -11,30 +11,58 @@ import (
 	"go.uber.org/zap"
 )
 
+// resolveWatchRoot returns the absolute, symlink-resolved directory that the
+// watcher should be rooted at.
+//
+// This exists because filepath.Walk lstat()s its root and refuses to descend
+// into a symlink, so a working_dir like the `releases/active -> releases/main`
+// indirection common to release-directory deploys would add zero watches and
+// silently never reload.
+//
+// CALLERS MUST KEY ANY PATH BOOKKEEPING OFF THE VALUE RETURNED HERE, not off
+// the configured directory. fsnotify reports events as
+// filepath.Join(<path given to Add>, name), so once the watcher is rooted at a
+// resolved path, every event carries the resolved prefix. DynamicApp matches
+// events against its dirToKeys map to decide which tenant to reload; keying
+// that map off the unresolved path silently drops every event. Note this is
+// not limited to a symlinked working_dir — EvalSymlinks resolves every path
+// component, so a symlinked ancestor (macOS /var and /tmp, a symlinked /home
+// or /srv, a container's /app) is enough to make the two disagree.
+//
+// On error the absolute path is returned unchanged, which leaves a root whose
+// components contain no symlinks behaving exactly as before.
+func resolveWatchRoot(dir string, logger *zap.Logger) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// Broken, missing or unreadable path: fall back to the literal one.
+		logger.Warn("autoreload: failed to resolve working directory symlinks",
+			zap.String("path", abs),
+			zap.Error(err),
+		)
+		return abs, nil
+	}
+	if resolved != abs {
+		// Debug, not Info: this fires for any symlinked ancestor, so on macOS
+		// (/var -> private/var) it would otherwise log on every single app.
+		logger.Debug("autoreload: resolved working directory",
+			zap.String("path", abs),
+			zap.String("resolved", resolved),
+		)
+	}
+	return resolved, nil
+}
+
 // watchDirRecursive adds all directories under root to the fsnotify watcher.
 // It is used by both AutoreloadableApp and DynamicApp.
 //
-// The root is resolved through symlinks first. filepath.Walk lstat()s its root
-// and refuses to descend into a symlink, so a working_dir like the
-// `releases/active -> releases/main` indirection common to release-directory
-// deploys would otherwise add zero watches and silently never reload.
-// Only the root is resolved: symlinks *inside* the tree are still not followed,
-// so the walk stays free of cycles and of excursions outside the app.
+// root must already have been passed through resolveWatchRoot. Symlinks
+// *inside* the tree are not followed by the initial walk, so it stays free of
+// cycles and of excursions outside the app.
 func watchDirRecursive(watcher *fsnotify.Watcher, root string, logger *zap.Logger) {
-	if resolved, err := filepath.EvalSymlinks(root); err != nil {
-		// Broken or unreadable link: fall back to the literal path, which
-		// leaves a non-symlinked root behaving exactly as before.
-		logger.Warn("autoreload: failed to resolve working directory symlinks",
-			zap.String("path", root),
-			zap.Error(err),
-		)
-	} else if resolved != root {
-		logger.Info("autoreload: resolved working directory symlink",
-			zap.String("path", root),
-			zap.String("resolved", resolved),
-		)
-		root = resolved
-	}
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -73,7 +101,11 @@ func handleNewDirEvent(event fsnotify.Event, watcher *fsnotify.Watcher) {
 	if !event.Has(fsnotify.Create) {
 		return
 	}
-	info, err := os.Stat(event.Name)
+	// Lstat, not Stat: Stat follows symlinks, so a symlink-to-directory created
+	// inside the tree at runtime would be watched and extend the watcher
+	// outside the app — inconsistent with the initial walk, which lstat()s and
+	// skips them.
+	info, err := os.Lstat(event.Name)
 	if err != nil || !info.IsDir() {
 		return
 	}
@@ -125,7 +157,15 @@ func NewAutoreloadableApp(
 		exitOnReloadFailure: exitOnReloadFailure,
 	}
 
-	watchDirRecursive(watcher, workingDir, logger)
+	watchRoot, err := resolveWatchRoot(workingDir, logger)
+	if err != nil {
+		logger.Warn("autoreload: failed to resolve working directory",
+			zap.String("working_dir", workingDir),
+			zap.Error(err),
+		)
+		watchRoot = workingDir
+	}
+	watchDirRecursive(watcher, watchRoot, logger)
 
 	go a.watch()
 

--- a/autoreload_test.go
+++ b/autoreload_test.go
@@ -354,4 +354,152 @@ func TestAutoreloadableApp_FileChangeTriggersReload_SymlinkedWorkingDir(t *testi
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected reload to be triggered through a symlinked working_dir")
 	}
+
+	// Pin HOW it resolved, not just that it fired. Without this, a "fix" that
+	// watched the link's parent directory, or that followed symlinks inside the
+	// tree, would also pass. The watch list must be exactly the resolved target
+	// and its subdirectory.
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	want := map[string]bool{
+		resolvedTarget:                       true,
+		filepath.Join(resolvedTarget, "pkg"): true,
+	}
+	got := a.watcher.WatchList()
+	if len(got) != len(want) {
+		t.Fatalf("watch list = %v, want exactly %v", got, want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected watched path %q, want one of %v", p, want)
+		}
+	}
+}
+
+// A symlink ANYWHERE in the working_dir's ancestry is enough to make the
+// watched path differ from the configured one, because EvalSymlinks resolves
+// every component — macOS /var and /tmp, a symlinked /home or /srv, a
+// container's /app. Nothing here is a symlinked working_dir, and it must still
+// reload. This is the case that silently regressed dynamic apps, and the one a
+// t.TempDir()-only test cannot see on Linux CI.
+func TestAutoreloadableApp_FileChangeTriggersReload_SymlinkedAncestor(t *testing.T) {
+	reloadCalled := make(chan struct{}, 1)
+
+	mockApp := &mockAppServer{}
+	base := t.TempDir()
+	realParent := filepath.Join(base, "real-parent")
+	workingDir := filepath.Join(realParent, "app")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	linkParent := filepath.Join(base, "link-parent")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	// The configured working_dir is a plain directory; only its PARENT is a link.
+	configured := filepath.Join(linkParent, "app")
+
+	a, err := NewAutoreloadableApp(mockApp, configured, func() (AppServer, error) {
+		select {
+		case reloadCalled <- struct{}{}:
+		default:
+		}
+		return mockApp, nil
+	}, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("NewAutoreloadableApp: %v", err)
+	}
+	defer a.Cleanup()
+
+	if err := os.WriteFile(filepath.Join(workingDir, "t.py"), []byte("x = 1"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	select {
+	case <-reloadCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected reload through a symlinked ancestor")
+	}
+}
+
+// A broken symlink must fall back to the literal path rather than panic, and
+// must leave the app serving.
+func TestAutoreloadableApp_BrokenSymlinkWorkingDir(t *testing.T) {
+	mockApp := &mockAppServer{}
+	base := t.TempDir()
+	link := filepath.Join(base, "active")
+	if err := os.Symlink(filepath.Join(base, "does-not-exist"), link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	a, err := NewAutoreloadableApp(mockApp, link, func() (AppServer, error) {
+		return mockApp, nil
+	}, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("NewAutoreloadableApp should tolerate a broken working_dir link: %v", err)
+	}
+	defer a.Cleanup()
+
+	if watched := a.watcher.WatchList(); len(watched) != 0 {
+		t.Errorf("expected no watches for a broken symlink, got %v", watched)
+	}
+}
+
+// DynamicApp matches fsnotify events against its dirToKeys map to decide which
+// tenant to reload. The watcher is rooted at the RESOLVED working directory, so
+// events carry the resolved prefix; if dirToKeys is keyed off the unresolved
+// path instead, every event is dropped and dynamic autoreload silently does
+// nothing while still logging "autoreload enabled". This test fails both when
+// the root is not resolved at all (zero watches) and when it is resolved on
+// only one of the two sides (watches, but no attribution).
+func TestDynamicApp_AutoreloadThroughSymlinkedWorkingDir(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "release")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	link := filepath.Join(base, "active")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	d, err := NewDynamicApp("main:app", link, "", nil, nil,
+		func(module, dir, venv string, envFiles []string, envVars map[string]string) (AppServer, error) {
+			return &mockAppServer{}, nil
+		},
+		zap.NewNop(),
+		true, // autoreload
+		nil, defaultDynamicAppLimits(),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicApp: %v", err)
+	}
+	defer d.Cleanup()
+
+	if _, err := d.getOrCreateApp("key1", "main:app", link, "", nil, nil); err != nil {
+		t.Fatalf("getOrCreateApp: %v", err)
+	}
+
+	// Write through the real path, as a deploy does.
+	if err := os.WriteFile(filepath.Join(target, "t.py"), []byte("x = 1"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// A reload evicts the cached app for that directory (cleanup is async).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		d.mu.RLock()
+		_, stillCached := d.apps["key1"]
+		d.mu.RUnlock()
+		if !stillCached {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected the dynamic app to be evicted by autoreload through a symlinked working_dir")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/autoreload_test.go
+++ b/autoreload_test.go
@@ -310,3 +310,48 @@ func TestAutoreloadableApp_FileChangeTriggersReload(t *testing.T) {
 		t.Fatal("expected reload to be triggered by .py file change")
 	}
 }
+
+// A working_dir that is itself a symlink is the normal shape of a
+// release-directory deploy (`releases/active -> releases/main`). filepath.Walk
+// lstat()s its root and does not descend into a symlink, so watching such a
+// root used to add zero watches and autoreload silently never fired.
+func TestAutoreloadableApp_FileChangeTriggersReload_SymlinkedWorkingDir(t *testing.T) {
+	reloadCalled := make(chan struct{}, 1)
+
+	mockApp := &mockAppServer{}
+	base := t.TempDir()
+	target := filepath.Join(base, "release")
+	nested := filepath.Join(target, "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	link := filepath.Join(base, "active")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	a, err := NewAutoreloadableApp(mockApp, link, func() (AppServer, error) {
+		select {
+		case reloadCalled <- struct{}{}:
+		default:
+		}
+		return mockApp, nil
+	}, zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("NewAutoreloadableApp: %v", err)
+	}
+	defer a.Cleanup()
+
+	// Write through the real path, as a deploy does — the watcher must have
+	// followed the link to see it, including into subdirectories.
+	pyFile := filepath.Join(nested, "test_trigger.py")
+	if err := os.WriteFile(pyFile, []byte("x = 1"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	select {
+	case <-reloadCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected reload to be triggered through a symlinked working_dir")
+	}
+}

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -54,7 +54,7 @@ The autoreload feature provides hot-reloading during development without restart
 
 ### How it works
 
-1. A filesystem watcher ([fsnotify](https://github.com/fsnotify/fsnotify)) is started on the working directory, recursively watching all subdirectories
+1. A filesystem watcher ([fsnotify](https://github.com/fsnotify/fsnotify)) is started on the working directory, recursively watching all subdirectories. The directory is resolved through symlinks first, since `filepath.Walk` will not descend a symlinked root
 2. Only `.py` file events are considered (write, create, remove, rename)
 3. Rapid changes are debounced with a 500ms window (e.g. when an editor saves and auto-formats)
 4. When the debounce fires:
@@ -112,7 +112,7 @@ When `autoreload` is enabled on a dynamic app, each resolved working directory g
 
 - A `dirToKeys` map tracks which cache keys belong to each working directory
 - When a `.py` file changes, only the apps for that directory are evicted
-- Old app instances are retired immediately and cleaned up when their active request count reaches zero
+- Old app instances are evicted immediately; their workers are cleaned up after a fixed 10s grace period, which does **not** wait for active requests
 - The app is lazily reimported on the next request
 - If the reimport fails on the next request, the process terminates (when `exitOnReloadFailure` is configured)
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -302,15 +302,24 @@ python {
 **How it works:**
 - Uses filesystem notifications (via [fsnotify](https://github.com/fsnotify/fsnotify)) to watch for `.py` file changes (write, create, remove, rename)
 - Changes are debounced with a 500ms window to group rapid edits (e.g. editor save + format)
-- The Python module cache (`sys.modules`) is invalidated for all modules in the working directory before reimporting
+- A reload starts **fresh Python worker processes** via the factory. It is not an in-process reimport, so there is no `sys.modules` cache to invalidate — each new worker is a new interpreter
 - The old app is cleaned up and a new one is created seamlessly
 - In-flight requests complete before the swap happens (thread-safe with read/write locks)
 - If a static-app reload fails (e.g. syntax error in Python code), the app returns HTTP 503 until the next file change triggers a successful reload
 - Reload failures do not terminate Caddy in the normal Caddyfile and CLI wiring
-- A `working_dir` that is itself a symlink is resolved to its target before watching, so the release-directory pattern (`releases/active -> releases/main`) works. Symlinks *inside* the tree are not followed
+- The working directory is resolved through symlinks before watching, so the release-directory pattern (`releases/active -> releases/main`) works — for both static and dynamic apps. Symlinks *inside* the tree are not followed
 
-:::caution
-The watched tree is resolved once, when the app starts. Re-pointing a symlinked `working_dir` at a **new** directory does not move the watcher — the old target stays watched. Deploys that swap the symlink to a fresh release directory need a Caddy reload (or restart) to pick the new tree up; deploys that write in place over the existing target are picked up normally.
+:::warning
+`autoreload` is a development feature. Two properties make it a poor fit for production:
+
+- **The swap waits for in-flight requests, and queues new ones behind them.** A request holds a read lock for its whole lifetime and the reload takes the write lock; Go's `RWMutex` gives a waiting writer priority, so new requests block too. With a WebSocket or a streaming response open, the app stops serving until that connection closes. Reload Caddy instead (`caddy reload --force`), which keeps listeners up and does not block.
+- **The 500ms debounce is tuned for an editor save, not a deploy.** With `tar`/`rsync` it can fire against a half-extracted tree.
+:::
+
+:::warning
+The watched tree is resolved once, when the app starts. Re-pointing a symlinked `working_dir` at a **new** directory does not move the watcher — the old target stays watched, so a Caddy reload (or restart) is needed to pick the new tree up. Deploys that write in place over the existing target are picked up normally.
+
+If the old release directory is then **deleted**, the kernel drops those watches and nothing re-adds them: autoreload goes silently dead for the lifetime of the process. Release schemes that prune old releases should reload Caddy on deploy rather than rely on `autoreload`.
 :::
 
 ### `isolation`
@@ -420,7 +429,9 @@ Dynamic module loading works with `autoreload`. When enabled, each resolved work
 }
 ```
 
-Old app instances are retired immediately and cleaned up after their in-flight requests complete.
+Old app instances are evicted immediately and their worker processes are cleaned up after a fixed 10s
+grace period. Unlike idle/LRU eviction, this does **not** wait for active requests: a request still
+running 10s after the reload has its worker killed under it.
 
 ---
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -307,6 +307,11 @@ python {
 - In-flight requests complete before the swap happens (thread-safe with read/write locks)
 - If a static-app reload fails (e.g. syntax error in Python code), the app returns HTTP 503 until the next file change triggers a successful reload
 - Reload failures do not terminate Caddy in the normal Caddyfile and CLI wiring
+- A `working_dir` that is itself a symlink is resolved to its target before watching, so the release-directory pattern (`releases/active -> releases/main`) works. Symlinks *inside* the tree are not followed
+
+:::caution
+The watched tree is resolved once, when the app starts. Re-pointing a symlinked `working_dir` at a **new** directory does not move the watcher — the old target stays watched. Deploys that swap the symlink to a fresh release directory need a Caddy reload (or restart) to pick the new tree up; deploys that write in place over the existing target are picked up normally.
+:::
 
 ### `isolation`
 

--- a/dynamic.go
+++ b/dynamic.go
@@ -515,9 +515,19 @@ func (d *DynamicApp) getOrCreateApp(key, module, dir, venv string, envFiles []st
 		now = d.now()
 		d.apps[key] = app
 		d.lastUsed[key] = now
-		d.appDirs[key] = dir
+		// Store the RESOLVED dir. Eviction untracks by this value, and by then
+		// the release directory may be gone — resolving again at that point
+		// would fail, fall back to the unresolved path, silently fail to match
+		// dirToKeys, and leak the key. Resolve once, here, while it exists.
+		resolvedDir := dir
 		if d.autoreload && dir != "" {
-			d.startWatchingDir(dir, key)
+			if r, err := resolveWatchRoot(dir, d.logger); err == nil {
+				resolvedDir = r
+			}
+		}
+		d.appDirs[key] = resolvedDir
+		if d.autoreload && dir != "" {
+			d.startWatchingDir(resolvedDir, key)
 		}
 	} else {
 		d.rememberFailedCreateLocked(key, err)
@@ -584,12 +594,14 @@ func (d *DynamicApp) removeAppLocked(key string) AppServer {
 	delete(d.lastUsed, key)
 	// Leave inUse intact so a still-running handler's releaseApp cannot
 	// accidentally unpin a replacement app created for the same key.
+	// appDirs already holds the resolved watch root, which is what dirToKeys is
+	// keyed by. Do NOT re-resolve here: by eviction time the release directory
+	// is often gone, EvalSymlinks would fail, and the fallback would not match
+	// the key — silently leaking it into dirToKeys forever.
 	dir := d.appDirs[key]
 	delete(d.appDirs, key)
 	if d.autoreload && dir != "" {
-		if absDir, err := filepath.Abs(dir); err == nil {
-			d.untrackKeyLocked(absDir, key)
-		}
+		d.untrackKeyLocked(dir, key)
 	}
 	return app
 }
@@ -641,13 +653,15 @@ func (d *DynamicApp) cleanupAppsAsync(apps []AppServer) {
 		}
 	}()
 }
-func (d *DynamicApp) startWatchingDir(dir, key string) {
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		d.logger.Warn("autoreload: failed to resolve directory",
-			zap.String("dir", dir),
-			zap.Error(err),
-		)
+
+// startWatchingDir registers a watch for a tenant's working directory.
+//
+// absDir MUST be the value returned by resolveWatchRoot — the same string the
+// watcher is rooted at. fsnotify reports events under the path given to Add, so
+// keying dirToKeys off anything else (e.g. a bare filepath.Abs) makes
+// pathWithinDir fail for every event and silently disables dynamic autoreload.
+func (d *DynamicApp) startWatchingDir(absDir, key string) {
+	if absDir == "" {
 		return
 	}
 


### PR DESCRIPTION
## Problem

`autoreload` silently registers **zero watches** when `working_dir` is a symlink, so it never fires and there is no error, no warning, and nothing in the logs to say so.

`watchDirRecursive` walks the tree with `filepath.Walk`, which `Lstat`s its root. For a symlinked root the callback receives the symlink's own `FileInfo`, hits the `if !info.IsDir() { return nil }` guard, and `Walk` returns `nil` without descending. No `watcher.Add` call is ever made.

This is the normal layout for release-directory deploys:

```
/srv/releases/
├── 2024-06-01/
├── 2024-06-02/
└── active -> 2024-06-02      <- working_dir points here
```

Which is how I found it: a production deploy where `autoreload` had been configured for months and had never once worked.

## Fix

Resolve **only the root** through `filepath.EvalSymlinks` before walking, warning and falling back to the literal path if resolution fails (broken or unreadable link), which leaves a non-symlinked root behaving exactly as before.

Symlinks *inside* the tree are still not followed, so the walk stays free of cycles and of excursions outside the app.

## Test

`TestAutoreloadableApp_FileChangeTriggersReload_SymlinkedWorkingDir` builds `base/release/pkg/`, symlinks `base/active -> base/release`, points the app at the symlink, and writes a `.py` file through the real path — the way a deploy does.

Verified it is a genuine regression test:

```
$ git checkout origin/main -- autoreload.go && go test -run ..._SymlinkedWorkingDir .
--- FAIL: TestAutoreloadableApp_FileChangeTriggersReload_SymlinkedWorkingDir (5.00s)
    autoreload_test.go:355: expected reload to be triggered through a symlinked working_dir

$ git checkout HEAD -- autoreload.go && go test -run 'TestAutoreload' .
ok  	github.com/mliezun/caddy-snake	1.994s   (8/8 pass)
```

It `t.Skip`s where symlinks are unsupported.

## Docs

Added a "How it works" bullet plus a caution that the tree is resolved **once, at start** — so re-pointing a symlink at a *new* directory still needs a reload. That is the operationally important caveat for release-directory deploys: this fix makes autoreload see changes *within* the current target, not follow a symlink swap.

## Heads-up, not part of this PR

Making autoreload work on a symlinked `working_dir` will wake it up for exactly the deploy setups that were silently getting nothing. Two things worth knowing before that lands in anyone's production:

1. **`reload()` blocks on long-lived requests, and starves new ones.** `HandleRequest` holds `a.mu.RLock()` for a request's entire lifetime (it proxies to the worker), while `reload()` takes `a.mu.Lock()`. With a WebSocket or a streaming response open, the swap blocks — and Go's `RWMutex` starves new readers behind a waiting writer, so subsequent requests hang too. Measured against a 45s connection on `mliezun/caddy-snake:latest-py3.14`: three probe requests all timed out, and the app only recovered when the long request ended. `caddy reload --force` under the identical setup served the new code in 0.0s with nothing blocked.
2. The 500 ms debounce is tuned for an editor save, so on a `tar`/`rsync` deploy it can fire against a half-extracted tree.

Neither is introduced here, and I don't think either should block this — the current behaviour (silently never reloading) is strictly worse. Happy to open a separate issue for #1 with the repro if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem watch roots and dynamic autoreload path bookkeeping; incorrect resolution would still break reload silently, but behavior is covered by new symlink tests and only affects the autoreload code path.
> 
> **Overview**
> **Autoreload** now resolves `working_dir` through symlinks (`resolveWatchRoot` / `filepath.EvalSymlinks`) before `filepath.Walk` registers watches, fixing the case where a symlinked root (e.g. `releases/active -> releases/main`) added **zero** watches and never reloaded. Runtime directory adds use **`Lstat`** instead of **`Stat`** so symlinked dirs inside the tree are not followed inconsistently.
> 
> **Dynamic apps** with autoreload store and key `dirToKeys` / `appDirs` on that **same resolved** path at create time and stop re-resolving on eviction (avoids leaks and dropped events when the release dir is gone).
> 
> Docs/README clarify symlink-once-at-start behavior, that reload spawns **fresh workers** (not in-process `sys.modules` invalidation), dev-only production caveats (RWMutex + long-lived connections, debounce vs deploys), and dynamic autoreload cleanup after a **10s** grace period without waiting for in-flight requests.
> 
> New tests cover symlinked `working_dir`, symlinked ancestors, broken symlinks, and dynamic autoreload attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec060797e58203424f071e379bee98c2f8cc1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->